### PR TITLE
Zone text and coordinates

### DIFF
--- a/modules/minimap.lua
+++ b/modules/minimap.lua
@@ -38,4 +38,31 @@ pfUI:RegisterModule("minimap", function ()
   MiniMapMailIcon:SetTexture("Interface\\AddOns\\pfUI\\img\\mail")
 
   MiniMapTrackingFrame:SetFrameStrata("LOW")
+
+  -- Current location
+  -- Create location text frame under minimap
+  pfUI.minimapLocation = CreateFrame("Frame", nil, UIParent)
+  pfUI.minimapLocation:SetBackdrop(pfUI.backdrop)
+  pfUI.minimapLocation:SetBackdropColor(0,0,0,0)
+  pfUI.minimapLocation:SetPoint("TOPRIGHT",UIParent, -5, -7 - Minimap:GetHeight())
+  pfUI.minimapLocation:SetHeight(20)
+  pfUI.minimapLocation:SetWidth(Minimap:GetWidth())
+  pfUI.minimapLocation:SetFrameStrata("BACKGROUND")
+  pfUI.minimapLocation.background = pfUI.minimapLocation:CreateTexture(nil,"BACKGROUND")
+  pfUI.minimapLocation.background:SetTexture(0,0,0,1)
+  pfUI.minimapLocation.background:SetAllPoints(pfUI.minimapLocation)
+  -- Create text
+  pfUI.minimapLocation.text = pfUI.minimapLocation:CreateFontString("Status", "LOW", "GameFontNormal")
+  pfUI.minimapLocation.text:SetFont("Interface\\AddOns\\pfUI\\fonts\\arial.ttf", 9, "OUTLINE")
+  pfUI.minimapLocation.text:SetPoint("CENTER", 0, 0)
+  pfUI.minimapLocation.text:SetFontObject(GameFontWhite)
+  -- Register zone change event
+  pfUI.minimapLocation:RegisterEvent("ZONE_CHANGED")
+  local function zoneChangeEventHandler(self, event, ...)
+    pfUI.minimapLocation.text:SetText(GetZoneText())
+  end
+  pfUI.minimapLocation:SetScript("OnEvent", zoneChangeEventHandler)
+  -- Initiate zone text
+  zoneChangeEventHandler()
+
 end)

--- a/modules/minimap.lua
+++ b/modules/minimap.lua
@@ -56,14 +56,14 @@ pfUI:RegisterModule("minimap", function ()
   pfUI.minimapLocation.text:SetFont("Interface\\AddOns\\pfUI\\fonts\\arial.ttf", 9, "OUTLINE")
   pfUI.minimapLocation.text:SetPoint("CENTER", 0, 0)
   pfUI.minimapLocation.text:SetFontObject(GameFontWhite)
+  -- Initiate zone text
+  pfUI.minimapLocation.text:SetText(GetMinimapZoneText())
   -- Register zone change event
-  pfUI.minimapLocation:RegisterEvent("ZONE_CHANGED")
+  pfUI.minimapLocation:RegisterEvent("MINIMAP_ZONE_CHANGED")
   local function zoneChangeEventHandler(self, event, ...)
-    pfUI.minimapLocation.text:SetText(GetZoneText())
+    pfUI.minimapLocation.text:SetText(GetMinimapZoneText())
   end
   pfUI.minimapLocation:SetScript("OnEvent", zoneChangeEventHandler)
-  -- Initiate zone text
-  zoneChangeEventHandler()
 
   -- Coordinates in minimap
   -- Create location text frame in bottom left corner of minimap

--- a/modules/minimap.lua
+++ b/modules/minimap.lua
@@ -52,7 +52,7 @@ pfUI:RegisterModule("minimap", function ()
   pfUI.minimapLocation.background:SetTexture(0,0,0,1)
   pfUI.minimapLocation.background:SetAllPoints(pfUI.minimapLocation)
   -- Create text
-  pfUI.minimapLocation.text = pfUI.minimapLocation:CreateFontString("Status", "LOW", "GameFontNormal")
+  pfUI.minimapLocation.text = pfUI.minimapLocation:CreateFontString("MinimapZoneText", "LOW", "GameFontNormal")
   pfUI.minimapLocation.text:SetFont("Interface\\AddOns\\pfUI\\fonts\\arial.ttf", 9, "OUTLINE")
   pfUI.minimapLocation.text:SetPoint("CENTER", 0, 0)
   pfUI.minimapLocation.text:SetFontObject(GameFontWhite)
@@ -64,5 +64,37 @@ pfUI:RegisterModule("minimap", function ()
   pfUI.minimapLocation:SetScript("OnEvent", zoneChangeEventHandler)
   -- Initiate zone text
   zoneChangeEventHandler()
+
+  -- Coordinates in minimap
+  -- Create location text frame in bottom left corner of minimap
+  pfUI.minimapCoordinates = CreateFrame("Frame", nil, pfUI.minimap)
+  pfUI.minimapCoordinates:SetPoint("BOTTOMLEFT", 3, 3)
+  pfUI.minimapCoordinates:SetHeight(20)
+  pfUI.minimapCoordinates:SetWidth(40)
+  pfUI.minimapCoordinates:SetFrameStrata("BACKGROUND")
+  pfUI.minimapCoordinates.background = pfUI.minimapCoordinates:CreateTexture(nil,"BACKGROUND")
+  pfUI.minimapCoordinates.background:SetTexture(0,0,0,1)
+  pfUI.minimapCoordinates.background:SetAllPoints(pfUI.minimapCoordinates)
+  -- Create text
+  pfUI.minimapCoordinates.text = pfUI.minimapCoordinates:CreateFontString("MinimapCoordinatesText", "LOW", "GameFontNormal")
+  pfUI.minimapCoordinates.text:SetFont("Interface\\AddOns\\pfUI\\fonts\\arial.ttf", 11, "OUTLINE")
+  pfUI.minimapCoordinates.text:SetPoint("LEFT", 0, 0)
+  pfUI.minimapCoordinates.text:SetFontObject(GameFontWhite)
+  pfUI.minimapCoordinates.text:SetText("X, Y")
+  pfUI.minimapCoordinates:Hide()
+
+  -- Minimap hover event
+  -- Update and toggle showing of coordinates on mouse enter/leave
+  Minimap:SetScript("OnEnter", function()
+    SetMapToCurrentZone()
+    local posX, posY = GetPlayerMapPosition("player")
+    local roundedX = ceil(posX * 1000)/10
+    local roundedY = ceil(posY * 1000)/10
+    pfUI.minimapCoordinates.text:SetText(roundedX..", "..roundedY)
+    pfUI.minimapCoordinates:Show()
+  end)
+  Minimap:SetScript("OnLeave", function()
+    pfUI.minimapCoordinates:Hide()
+  end)
 
 end)


### PR DESCRIPTION
Added zone text under minimap and coordinates in minimap on mouse hover.

![image](https://cloud.githubusercontent.com/assets/6183607/15441503/88f61df4-1edb-11e6-89a5-8ca269e9291b.png)
