### PR TITLE
Easy config for changing chat height

### DIFF
--- a/modules/gui.lua
+++ b/modules/gui.lua
@@ -553,6 +553,8 @@ pfUI:RegisterModule("gui", function ()
 
   -- chat
   pfUI.gui.chat = pfUI.gui:CreateConfigTab("Chat")
+  pfUI.gui:CreateConfig(pfUI.gui.chat, "Left chat height:", pfUI_config.chat.text, "left_chat_height") 
+  pfUI.gui:CreateConfig(pfUI.gui.chat, "Right chat height:", pfUI_config.chat.text, "right_chat_height") 
   pfUI.gui:CreateConfig(pfUI.gui.chat, "Chat inputbox width:", pfUI_config.chat.text, "input_width")
   pfUI.gui:CreateConfig(pfUI.gui.chat, "Chat inputbox height:", pfUI_config.chat.text, "input_height")
   pfUI.gui:CreateConfig(pfUI.gui.chat, "Timestamp in chat:", pfUI_config.chat.text, "time", "checkbox")


### PR DESCRIPTION
After every update I have to manually change the left and right chat height to 200 from 150, I thought it would be easier if we could have an option for this in the Settings UI. Thanks!