### PR TITLE
Added option to hide right chat background.

### DIFF
--- a/modules/chat.lua
+++ b/modules/chat.lua
@@ -160,14 +160,18 @@ pfUI:RegisterModule("chat", function ()
   pfUI.chat.right:SetHeight(pfUI_config.chat.right.height)
   pfUI.chat.right:SetPoint("BOTTOMRIGHT", -5,5)
   pfUI.utils:UpdateMovable(pfUI.chat.right)
-  pfUI.utils:CreateBackdrop(pfUI.chat.right, default_border, nil, true)
+  if pfUI_config.panel.right.enable == "0" then
+    pfUI.utils:CreateBackdrop(pfUI.chat.right, default_border, nil, true)
+  end
 
   pfUI.chat.right.panelTop = CreateFrame("Frame", "rightChatPanelTop", pfUI.chat.right)
   pfUI.chat.right.panelTop:ClearAllPoints()
   pfUI.chat.right.panelTop:SetHeight(pfUI_config.global.font_size+default_border*2)
   pfUI.chat.right.panelTop:SetPoint("TOPLEFT", pfUI.chat.right, "TOPLEFT", default_border, -default_border)
   pfUI.chat.right.panelTop:SetPoint("TOPRIGHT", pfUI.chat.right, "TOPRIGHT", -default_border, -default_border)
-  pfUI.utils:CreateBackdrop(pfUI.chat.right.panelTop, default_border, nil, true)
+  if pfUI_config.panel.right.enable == "0" then
+    pfUI.utils:CreateBackdrop(pfUI.chat.right.panelTop, default_border, nil, true)
+  end
 
   pfUI.chat:RegisterEvent("PLAYER_ENTERING_WORLD")
   pfUI.chat:RegisterEvent("UI_SCALE_CHANGED")

--- a/modules/chat.lua
+++ b/modules/chat.lua
@@ -160,18 +160,14 @@ pfUI:RegisterModule("chat", function ()
   pfUI.chat.right:SetHeight(pfUI_config.chat.right.height)
   pfUI.chat.right:SetPoint("BOTTOMRIGHT", -5,5)
   pfUI.utils:UpdateMovable(pfUI.chat.right)
-  if pfUI_config.panel.right.enable == "0" then
-    pfUI.utils:CreateBackdrop(pfUI.chat.right, default_border, nil, true)
-  end
+  pfUI.utils:CreateBackdrop(pfUI.chat.right, default_border, nil, true)
 
   pfUI.chat.right.panelTop = CreateFrame("Frame", "rightChatPanelTop", pfUI.chat.right)
   pfUI.chat.right.panelTop:ClearAllPoints()
   pfUI.chat.right.panelTop:SetHeight(pfUI_config.global.font_size+default_border*2)
   pfUI.chat.right.panelTop:SetPoint("TOPLEFT", pfUI.chat.right, "TOPLEFT", default_border, -default_border)
   pfUI.chat.right.panelTop:SetPoint("TOPRIGHT", pfUI.chat.right, "TOPRIGHT", -default_border, -default_border)
-  if pfUI_config.panel.right.enable == "0" then
-    pfUI.utils:CreateBackdrop(pfUI.chat.right.panelTop, default_border, nil, true)
-  end
+  pfUI.utils:CreateBackdrop(pfUI.chat.right.panelTop, default_border, nil, true)
 
   pfUI.chat:RegisterEvent("PLAYER_ENTERING_WORLD")
   pfUI.chat:RegisterEvent("UI_SCALE_CHANGED")
@@ -550,4 +546,11 @@ pfUI:RegisterModule("chat", function ()
       end
     end
   end
+
+  -- Hide Right Chat panel
+  if pfUI_config.panel.right.enable == "0" then
+    pfUI.chat.right:Hide()
+    pfUI.chat.right.panelTop:Hide()
+  end
+
 end)

--- a/modules/gui.lua
+++ b/modules/gui.lua
@@ -658,7 +658,6 @@ pfUI:RegisterModule("gui", function ()
   pfUI.gui:CreateConfig(pfUI.gui.uf, "Click-cast on Raidframe (Ctrl)", pfUI_config.unitframes.raid, "clickcast_ctrl")
   pfUI.gui:CreateConfig(pfUI.gui.uf, "Show Buffs on Raidframes", pfUI_config.unitframes.raid, "buffs_buffs", "checkbox")
   pfUI.gui:CreateConfig(pfUI.gui.uf, "Show Hots on Raidframes", pfUI_config.unitframes.raid, "buffs_hots", "checkbox")
-  pfUI.gui:CreateConfig(pfUI.gui.uf, "Show Procs on Raidframes", pfUI_config.unitframes.raid, "buffs_procs", "checkbox")
   pfUI.gui:CreateConfig(pfUI.gui.uf, "Only display Hots of my class", pfUI_config.unitframes.raid, "buffs_classonly", "checkbox")
 
   -- actionbar
@@ -677,6 +676,7 @@ pfUI:RegisterModule("gui", function ()
   pfUI.gui:CreateConfig(pfUI.gui.panel, "Other Panel: Minimap", pfUI_config.panel.other, "minimap", "dropdown", values)
   pfUI.gui:CreateConfig(pfUI.gui.panel, "Always show XP and Reputation Bar", pfUI_config.panel.xp, "showalways", "checkbox")
   pfUI.gui:CreateConfig(pfUI.gui.panel, "Show Menubar", pfUI_config.panel.micro, "enable", "checkbox")
+  pfUI.gui:CreateConfig(pfUI.gui.panel, "Show Right Panel", pfUI_config.panel.right, "enable", "checkbox")
 
   -- tooltip
   pfUI.gui.tooltip = pfUI.gui:CreateConfigTab("Tooltip")

--- a/modules/panel.lua
+++ b/modules/panel.lua
@@ -522,4 +522,12 @@ pfUI:RegisterModule("panel", function ()
       button:Show()
     end
   end
+-- Hide Right Chat panel
+if pfUI_config.panel.right.enable == "0" then
+  pfUI.panel.right:Hide()
+  pfUI.panel.right.left.text:Hide()
+  pfUI.panel.right.center.text:Hide()
+  pfUI.panel.right.right.text:Hide()
+end
+
 end)


### PR DESCRIPTION
I made a small hack to be able to disable the background of the right panel window. This is just a hack it should properly be handled different but it works for now.