### PR TITLE
Fixed bug with eqcompare frames

### DIFF
--- a/modules/eqcompare.lua
+++ b/modules/eqcompare.lua
@@ -71,6 +71,9 @@ pfUI:RegisterModule("eqcompare", function ()
 
           ShoppingTooltip1:SetInventoryItem("player", slotID)
           ShoppingTooltip1:Show();
+          ShoppingTooltip1:SetScript("OnUpdate", function()
+          	if not IsShiftKeyDown() then this:Hide() end
+          end)
 
           -- second tooltip
           if pfUI.slotTable[slotType .. "_other"] then
@@ -87,6 +90,9 @@ pfUI:RegisterModule("eqcompare", function ()
 
             ShoppingTooltip2:SetInventoryItem("player", slotID_other)
             ShoppingTooltip2:Show();
+            ShoppingTooltip2:SetScript("OnUpdate", function()
+          		if not IsShiftKeyDown() then this:Hide() end
+          	end)
           end
 
         end


### PR DESCRIPTION
When you mouse over item, press shift and then release it frame didn't hide. I made a simple bugfix for that.  