### PR TITLE
eqcompare: shopping tooltip not hiding bug fixed

### DIFF
--- a/modules/eqcompare.lua
+++ b/modules/eqcompare.lua
@@ -43,7 +43,11 @@ pfUI:RegisterModule("eqcompare", function ()
 
   pfUI.eqcompare = CreateFrame( "Frame" , "pfEQCompare", GameTooltip )
   pfUI.eqcompare:SetScript("OnShow", function()
-    if not IsShiftKeyDown() then return end
+    if not IsShiftKeyDown() then 
+      ShoppingTooltip1:Hide();
+      ShoppingTooltip2:Hide();
+      return 
+    end
     local border = tonumber(pfUI_config.appearance.border.default)
 
     for i=1,GameTooltip:NumLines() do


### PR DESCRIPTION
Next approach to fix this bug. Now it works pretty well and doesn't mess with ShoppingTooltip scripts.