### PR TITLE
Fixed bug with player coordinates inconsistency

### DIFF
--- a/modules/minimap.lua
+++ b/modules/minimap.lua
@@ -115,9 +115,7 @@ pfUI:RegisterModule("minimap", function ()
     SetMapToCurrentZone()
     local posX, posY = GetPlayerMapPosition("player")
     if posX ~= 0 and posY ~= 0 then
-      local roundedX = ceil(posX * 1000)/10
-      local roundedY = ceil(posY * 1000)/10
-      pfUI.minimapCoordinates.text:SetText(roundedX..", "..roundedY)
+      pfUI.minimapCoordinates.text:SetText(round(posX * 100, 1) .. ", " .. round(posY * 100, 1))
     else
       pfUI.minimapCoordinates.text:SetText("|cffffaaaaN/A")
     end

--- a/modules/panel.lua
+++ b/modules/panel.lua
@@ -352,14 +352,18 @@ pfUI:RegisterModule("panel", function ()
 
   function pfUI.panel:UpdateZone ()
     local tooltip = function ()
-      local posX, posY = GetPlayerMapPosition("player")
       local real = GetRealZoneText()
       local sub = GetSubZoneText()
       GameTooltip:ClearLines()
       GameTooltip_SetDefaultAnchor(GameTooltip, this)
       GameTooltip:AddLine("|cffffffff" .. real)
       GameTooltip:AddLine(sub)
-      GameTooltip:AddLine("|cffaaaaaa" .. round(posX*100,1) .. " / " .. round(posY*100,1))
+
+      local posX, posY = GetPlayerMapPosition("player")
+      if posX ~= 0 and posY ~= 0 then
+        GameTooltip:AddLine("|cffaaaaaa" .. round(posX * 100, 1) .. ", " .. round(posY * 100, 1))
+      end
+
       GameTooltip:Show()
     end
 


### PR DESCRIPTION
There is a small bug with player coordinates inconsistency:
1) mouseover minimap - the minimap corner shows one coords;
2) mouseover location title under minimap - the tooltip shows other coords;
Please see screenshot -- http://i.imgur.com/RdboPjW.jpg

This is due to different rounding algorithms.
So i made this PR wich actually does next:
1) rounding now the same -- via "round";
2) formatting now the same -- comma separated (it was "/" for "panel");
3) "minimap" has kind of error checking -- "posX ~= 0 and posY ~= 0", so i added this checking to "panel" too;
