### PR TITLE
Fps panel

### DIFF
--- a/modules/panel.lua
+++ b/modules/panel.lua
@@ -168,7 +168,9 @@ pfUI:RegisterModule("panel", function ()
 
       local _, _, lag = GetNetStats()
       local fps = floor(GetFramerate())
-      pfUI.panel:OutputPanel("fps", fps .. " fps & " .. lag .. " ms", tooltip, click)
+      local memorykb = gcinfo()
+      local memorymb = floor(memorykb/1000)
+      pfUI.panel:OutputPanel("fps", fps .. " fps    " .. lag .. " ms    " .. memorymb .. " mb", tooltip, click)
     end
   end)
 

--- a/modules/panel.lua
+++ b/modules/panel.lua
@@ -168,7 +168,7 @@ pfUI:RegisterModule("panel", function ()
 
       local _, _, lag = GetNetStats()
       local fps = floor(GetFramerate())
-      pfUI.panel:OutputPanel("fps", floor(GetFramerate()) .. " fps & " .. lag .. " ms", tooltip, click)
+      pfUI.panel:OutputPanel("fps", fps .. " fps & " .. lag .. " ms", tooltip, click)
     end
   end)
 


### PR DESCRIPTION
1. Fix double fps calculation by just using the local fps variable.

2. Added addons-memory calculation to the fps counter on the pfui panel. This shows how much MB ram your addons currently consume.