### PR TITLE
mirrortimers: make them movable

### DIFF
--- a/modules/mirrortimers.lua
+++ b/modules/mirrortimers.lua
@@ -5,8 +5,13 @@ pfUI:RegisterModule("mirrortimers", function ()
     local text = _G["MirrorTimer"..i.."Text"]
     local border = _G["MirrorTimer"..i.."Border"]
 
+    text:Hide()
+    border:Hide()
+
     mirrorTimer:GetRegions():Hide()
     mirrorTimer.label = text
+    mirrorTimer.scale = 1
+    mirrorTimer.value = 0
 
     statusBar:SetStatusBarTexture("Interface\\AddOns\\pfUI\\img\\bar")
     statusBar:SetWidth(222)
@@ -14,8 +19,15 @@ pfUI:RegisterModule("mirrortimers", function ()
     statusBar:SetPoint("TOP", 0, 0)
     CreateBackdrop(statusBar)
 
-    text:Hide()
-    border:Hide()
+    mirrorTimer:SetWidth(statusBar:GetWidth())
+    mirrorTimer:SetHeight(statusBar:GetHeight())
+
+    if (i ~= 1) then
+      mirrorTimer:ClearAllPoints()
+      mirrorTimer:SetPoint("CENTER", _G["MirrorTimer"..(i-1)], "CENTER", 0, -26)
+    end
+
+    UpdateMovable(mirrorTimer)
 
     local TimerText = mirrorTimer:CreateFontString(nil, "OVERLAY")
     TimerText:SetFont(pfUI.font_default, 12, "OUTLINE")
@@ -24,10 +36,16 @@ pfUI:RegisterModule("mirrortimers", function ()
 
     hooksecurefunc("MirrorTimerFrame_OnUpdate", function(frame, elapsed)
       if frame.paused then return end
+      if not frame.value then return end
+      if not frame.scale then return end
 
       local minutes = frame.value / 60
       local seconds = frame.value - math.floor(frame.value / 60) * 60
       local text = frame.label:GetText()
+
+      if not text then return end
+
+      if not frame:IsShown() then frame:Show() end
 
       if frame.value > 0 then
         frame.TimerText:SetText(format("%s (%d:%02d)", text, minutes, seconds))

--- a/modules/thirdparty.lua
+++ b/modules/thirdparty.lua
@@ -805,7 +805,7 @@ pfUI:RegisterModule("thirdparty", function ()
 
   do -- FlightMap Integration
     if C.thirdparty.flightmap.enable == "0" then return end
-    if not FlightMapTimesFrame and not FlightMapTimesFrame and not FlightMapTimesText then return end
+    if not FlightMapTimesBorder and not FlightMapTimesFrame and not FlightMapTimesText then return end
 
     FlightMapTimesBorder:Hide()
 

--- a/modules/unlock.lua
+++ b/modules/unlock.lua
@@ -76,7 +76,10 @@ pfUI:RegisterModule("unlock", function ()
           frame.drag.text:SetAllPoints(frame.drag)
           frame.drag.text:SetPoint("CENTER", 0, 0)
           frame.drag.text:SetFontObject(GameFontWhite)
-          local label = (strsub(frame:GetName(),3))
+          local label = frame:GetName()
+          -- Check if the frame name starts with pf if so remove it
+          local startsWithPf = string.sub(label, 1, string.len("pf")) == "pf"
+          if startsWithPf then label = (strsub(frame:GetName(),3)) end
           if frame.drag:GetHeight() > (2 * frame.drag:GetWidth()) then
             label = strvertical(label)
           end


### PR DESCRIPTION
Pretty debatable unlock change. Should only substring the frame label name if starts with pf. This allows blizzard frames and other non pf frames to be able to be movables and have the label show correctly.