### PR TITLE
minimap: improve zone text options

### DIFF
--- a/api/config.lua
+++ b/api/config.lua
@@ -65,7 +65,7 @@ function pfUI:LoadConfig()
   pfUI:UpdateConfig("appearance", "infight",     "group",            "0")
   pfUI:UpdateConfig("appearance", "bags",        "borderlimit",      "1")
   pfUI:UpdateConfig("appearance", "bags",        "borderonlygear",   "0")
-  pfUI:UpdateConfig("appearance", "minimap",     "mouseoverzone",    "0")
+  pfUI:UpdateConfig("appearance", "minimap",     "zoneloc",          "zonepanel")
   pfUI:UpdateConfig("appearance", "minimap",     "coordsloc",        "bottomleft")
 
   pfUI:UpdateConfig("loot",       nil,           "autoresize",       "1")

--- a/env/translations_deDE.lua
+++ b/env/translations_deDE.lua
@@ -168,7 +168,6 @@ pfUI_translation["deDE"] = {
   ["Enable Target Switch Animation"] = nil,
   ["Enable Timestamps"] = nil,
   ["Enable URL Detection"] = nil,
-  ["Enable Zone Text On Minimap Mouseover"] = nil,
   ["Experience"] = nil,
   ["Exp"] = nil,
   ["Fast"] = nil,

--- a/env/translations_enUS.lua
+++ b/env/translations_enUS.lua
@@ -168,7 +168,6 @@ pfUI_translation["enUS"] = {
   ["Enable Target Switch Animation"] = nil,
   ["Enable Timestamps"] = nil,
   ["Enable URL Detection"] = nil,
-  ["Enable Zone Text On Minimap Mouseover"] = nil,
   ["Experience"] = nil,
   ["Exp"] = nil,
   ["Fast"] = nil,

--- a/env/translations_esES.lua
+++ b/env/translations_esES.lua
@@ -168,7 +168,6 @@ pfUI_translation["esES"] = {
   ["Enable Target Switch Animation"] = nil,
   ["Enable Timestamps"] = nil,
   ["Enable URL Detection"] = nil,
-  ["Enable Zone Text On Minimap Mouseover"] = nil,
   ["Experience"] = nil,
   ["Exp"] = nil,
   ["Fast"] = nil,

--- a/env/translations_frFR.lua
+++ b/env/translations_frFR.lua
@@ -168,7 +168,6 @@ pfUI_translation["frFR"] = {
   ["Enable Target Switch Animation"] = "Activer l'animation au changement de cible",
   ["Enable Timestamps"] = "Activer les horaires de discussion",
   ["Enable URL Detection"] = "Activer la détection des adresses URL",
-  ["Enable Zone Text On Minimap Mouseover"] = "Activer l'affichage du nom de zone au survol de la minicarte",
   ["Experience"] = "Expérience",
   ["Exp"] = nil,
   ["Fast"] = "Rapide",

--- a/env/translations_koKR.lua
+++ b/env/translations_koKR.lua
@@ -168,7 +168,6 @@ pfUI_translation["koKR"] = {
   ["Enable Target Switch Animation"] = "대상 전환 애니메이션 사용",
   ["Enable Timestamps"] = "시간표시 사용",
   ["Enable URL Detection"] = "URL 감시 사용",
-  ["Enable Zone Text On Minimap Mouseover"] = "미니맵 마우스 오버시 지역보기 사용",
   ["Exp"] = "경험치",
   ["Experience"] = "경험치",
   ["Fast"] = "빠르게",

--- a/env/translations_ruRU.lua
+++ b/env/translations_ruRU.lua
@@ -168,7 +168,6 @@ pfUI_translation["ruRU"] = {
   ["Enable Target Switch Animation"] = "Включить анимацию переключения цели",
   ["Enable Timestamps"] = "Включить отметки времени",
   ["Enable URL Detection"] = "Включить обнаружение URL",
-  ["Enable Zone Text On Minimap Mouseover"] = "Включить текст зоны на миникарте при наведении мыши",
   ["Experience"] = "Опыт",
   ["Exp"] = "Опыт",
   ["Fast"] = "Быстро",

--- a/env/translations_zhCN.lua
+++ b/env/translations_zhCN.lua
@@ -168,7 +168,6 @@ pfUI_translation["zhCN"] = {
   ["Enable Target Switch Animation"] = "启用目标切换动画",
   ["Enable Timestamps"] = "启用时间戳",
   ["Enable URL Detection"] = "启用超链接检测",
-  ["Enable Zone Text On Minimap Mouseover"] = "鼠标悬停时显示区域名称",
   ["Experience"] = "经验值",
   ["Exp"] = "经验",
   ["Fast"] = "快速",

--- a/env/translations_zhTW.lua
+++ b/env/translations_zhTW.lua
@@ -168,7 +168,6 @@ pfUI_translation["zhTW"] = {
   ["Enable Target Switch Animation"] = "啟用目標切換動畫",
   ["Enable Timestamps"] = "啟用時間戳記",
   ["Enable URL Detection"] = "啟用超連結檢測",
-  ["Enable Zone Text On Minimap Mouseover"] = "滑鼠懸停時顯示區域名稱",
   ["Experience"] = "經驗值",
   ["Exp"] = "經驗",
   ["Fast"] = "快速",

--- a/modules/gui.lua
+++ b/modules/gui.lua
@@ -478,6 +478,13 @@ pfUI:RegisterModule("gui", function ()
     "off:" .. T["Disabled"]
   }
 
+  pfUI.gui.dropdowns.minimap_zone_options = {
+    "zonepanel:" .. T["Zone Panel"],
+    "highlighttext:" .. T["Minimap Highlight Text"],
+    "both:" .. T["Both"],
+    "off:" .. T["Disabled"]
+  }
+
   pfUI.gui.dropdowns.num_actionbar_buttons = BarLayoutOptions(NUM_ACTIONBAR_BUTTONS)
   pfUI.gui.dropdowns.num_shapeshift_slots = BarLayoutOptions(NUM_SHAPESHIFT_SLOTS)
   pfUI.gui.dropdowns.num_pet_action_slots = BarLayoutOptions(NUM_PET_ACTION_SLOTS)
@@ -1134,7 +1141,7 @@ pfUI:RegisterModule("gui", function ()
   pfUI.gui.tabs.minimap.tabs.general = pfUI.gui.tabs.minimap.tabs:CreateTabChild(T["Minimap"], 70)
   pfUI.gui.tabs.minimap.tabs.general:SetScript("OnShow", function()
     if not this.setup then
-      CreateConfig(this, T["Enable Zone Text On Minimap Mouseover"], C.appearance.minimap, "mouseoverzone", "checkbox")
+      CreateConfig(this, T["Zone Text Location"], C.appearance.minimap, "zoneloc", "dropdown", pfUI.gui.dropdowns.minimap_zone_options)
       CreateConfig(this, T["Coordinates Location"], C.appearance.minimap, "coordsloc", "dropdown", pfUI.gui.dropdowns.minimap_cords_position)
       CreateConfig(this, T["Disable Minimap Buffs"], C.global, "hidebuff", "checkbox")
       CreateConfig(this, T["Disable Minimap Weapon Buffs"], C.global, "hidewbuff", "checkbox")

--- a/modules/minimap.lua
+++ b/modules/minimap.lua
@@ -139,7 +139,7 @@ pfUI:RegisterModule("minimap", function ()
       pfUI.minimapCoordinates:Show()
     end
 
-    if C.appearance.minimap.mouseoverzone == "1" then
+    if C.appearance.minimap.zoneloc == "highlighttext" or C.appearance.minimap.zoneloc == "both" then
       local pvp, _, arena = GetZonePVPInfo()
       if arena then
         pfUI.minimapZone.text:SetTextColor(1.0, 0.1, 0.1)

--- a/modules/panel.lua
+++ b/modules/panel.lua
@@ -647,6 +647,10 @@ pfUI:RegisterModule("panel", function ()
   pfUI.panel.minimap.text:SetPoint("CENTER", 0, 0)
   pfUI.panel.minimap.text:SetFontObject(GameFontWhite)
 
+  if C.appearance.minimap.zoneloc == "highlighttext" or C.appearance.minimap.zoneloc == "off" then 
+    pfUI.panel.minimap:Hide() 
+  end
+
   -- MicroButtons
   if C.panel.micro.enable == "1" then
     pfUI.panel.microbutton = CreateFrame("Frame", "pfPanelMicroButton", UIParent)


### PR DESCRIPTION
This change easy allows the zone text panel to be hidden which was requested on the [forums](https://forum.elysium-project.org/topic/29034-addon-pfui-an-elvui-inspired-addon-entirely-written-from-scratch/?page=15&tab=comments#comment-442937).