### PR TITLE
Added support for more warlock spells in group frames

### DIFF
--- a/api/unitframes.lua
+++ b/api/unitframes.lua
@@ -1255,6 +1255,18 @@ function pfUI.uf:SetupBuffFilter()
 
     -- Soulstone
     table.insert(pfUI.uf.buffs, "interface\\icons\\spell_shadow_soulgem")
+
+    -- Unending Breath
+    table.insert(pfUI.uf.buffs, "interface\\icons\\spell_shadow_demonbreath")
+
+    -- Detect Greater Invisibility or Detect Invisibility
+    table.insert(pfUI.uf.buffs, "interface\\icons\\spell_shadow_detectinvisibility")
+
+    -- Detect Lesser Invisibility
+    table.insert(pfUI.uf.buffs, "interface\\icons\\spell_shadow_detectlesserinvisibility")
+
+    -- Paranoia
+    table.insert(pfUI.uf.buffs, "interface\\icons\\Spell_Shadow_AuraOfDarkness")
   end
 
 


### PR DESCRIPTION
Unending Breath
Detect Greater Invisibility
Detect Invisibility
Detect Lesser Invisibility
Paranoia

question: somehow you can do a check of the buff not only on the icon, but also on the name? Because suddenly the player will have a buff that has an similar icon with another buff from the ones specified in the addon and this will cause a false triggering.

Example in PR: Detect Greater Invisibility and Detect Invisibility spells.