### PR TITLE
panel: exp: fixed division by zero on level up

### DIFF
--- a/modules/panel.lua
+++ b/modules/panel.lua
@@ -220,8 +220,12 @@ pfUI:RegisterModule("panel", function ()
       if oldexp ~= nil then
         difexp = curexp - oldexp
         maxexp = UnitXPMax("player")
-        remexp = floor((maxexp - curexp)/difexp)
-        remstring = "|cff555555 [" .. remexp .. "]|r"
+        if difexp > 0 then
+          remexp = floor((maxexp - curexp)/difexp)
+          remstring = "|cff555555 [" .. remexp .. "]|r"
+        else
+          remstring = nil
+        end
       end
       oldexp = curexp
 


### PR DESCRIPTION
When player selects to display **XP Percentage** for a panel slot, there is non critical division by zero.

![panel_exp_bug_on_levelup](https://user-images.githubusercontent.com/1086543/32761156-719e13a8-c8fa-11e7-9a58-a7132a35cbf9.jpg)

This PR fixes it.