### PR TITLE
Prevent some UI widgets from going off-screen

### DIFF
--- a/modules/bags.lua
+++ b/modules/bags.lua
@@ -3,6 +3,7 @@ pfUI:RegisterModule("bags", function ()
   if C.appearance.border.bags ~= "-1" then
     default_border = C.appearance.border.bags
   end
+  StackSplitFrame:SetClampedToScreen(true)
 
   -- overwrite some bag functions
   function _G.OpenAllBags()

--- a/modules/tooltip.lua
+++ b/modules/tooltip.lua
@@ -1,5 +1,6 @@
 pfUI:RegisterModule("tooltip", function ()
 local alpha = tonumber(C.tooltip.alpha)
+GameTooltip:SetClampedToScreen(true)
 CreateBackdrop(GameTooltip, nil, nil, alpha)
 
   if C.tooltip.position == "cursor" then
@@ -111,6 +112,7 @@ CreateBackdrop(GameTooltip, nil, nil, alpha)
       end
   end)
 
+  GameTooltipStatusBar:SetClampedToScreen(true)
   GameTooltipStatusBar:SetHeight(6)
   GameTooltipStatusBar:ClearAllPoints()
   GameTooltipStatusBar:SetPoint("BOTTOMLEFT", GameTooltip, "TOPLEFT", 0, 0)


### PR DESCRIPTION
Prevent StackSplitFrame from going off-screen.
Prevent Tooltip from going off-screen when anchored to cursor.
Closes #770 #774