### PR TITLE
Table Wipe fix and RAID UnitPopup_Menu improvement

### DIFF
--- a/api/api.lua
+++ b/api/api.lua
@@ -412,7 +412,6 @@ function pfUI.api.wipe(src)
   for k in pairs(src) do
     src[k] = nil
   end
-  table.setn(src,0)
   return src
 end
 

--- a/api/unitframes.lua
+++ b/api/unitframes.lua
@@ -1131,6 +1131,9 @@ function pfUI.uf:ClickAction(button)
     elseif label == "party" then
       ToggleDropDownMenu(1, nil, getglobal("PartyMemberFrame" .. this.id .. "DropDown"), "cursor")
     elseif label == "raid" then
+      -- RaidFrameDropDown_Initialize expects .name and .unit attributes on raid unit buttons
+      if not (this.name) then this.name = this.lastUnit end
+      if not (this.unit) then this.unit = unitstr end
       ToggleDropDownMenu(1, nil, getglobal("RaidMemberFrame" .. this.id .. "DropDown"), "cursor")
       FriendsDropDown.initialize = RaidFrameDropDown_Initialize
       FriendsDropDown.displayMode = "MENU"


### PR DESCRIPTION
api: Prevent race condition in table wipe. Fixes masterlooter random and raidroll options.

unitframes: Fix raid unitpopup menu for 3rd party addons. Fixes set banker, disenchanter options.