### PR TITLE
Fix invalid layout sizes for ShapeshiftBar.

### DIFF
--- a/api/api.lua
+++ b/api/api.lua
@@ -635,11 +635,16 @@ end
 -- [ Bar Layout Size ] --
 -- 'bar'  frame reference,
 -- 'barsize'  integer number of buttons,
--- 'formfactor'  string formfactor in cols x rows
-function pfUI.api.BarLayoutSize(bar,barsize,formfactor,iconsize,bordersize)
+-- 'formfactor'  string formfactor in cols x rows,
+-- 'visiblesize' integer buttons actually spawned
+function pfUI.api.BarLayoutSize(bar,barsize,formfactor,iconsize,bordersize,visiblesize)
   assert(barsize > 0 and barsize <= NUM_ACTIONBAR_BUTTONS,"BarLayoutSize: barsize "..tostring(barsize).." is invalid")
   local formfactor = pfUI.api.BarLayoutFormfactor(formfactor)
   local cols, rows = unpack(pfGridmath[barsize][formfactor])
+  if (visiblesize) and (visiblesize < barsize) then
+    cols = math.min(cols,visiblesize)
+    rows = math.min(math.ceil(visiblesize/cols),visiblesize)
+  end  
   local width = (iconsize + bordersize*3) * cols - bordersize
   local height = (iconsize + bordersize*3) * rows - bordersize
   bar._size = {width,height}

--- a/modules/actionbar.lua
+++ b/modules/actionbar.lua
@@ -283,7 +283,7 @@ pfUI:RegisterModule("actionbar", function ()
         pfUI.bars.shapeshift:SetPoint("BOTTOM", anchor, "TOP", 0, default_border * 3)
         UpdateMovable(pfUI.bars.shapeshift)
         if C.bars.background == "1" then CreateBackdrop(pfUI.bars.shapeshift, default_border) end
-        BarLayoutSize(pfUI.bars.shapeshift, shapeshiftbuttons, C.bars.shapeshift.formfactor, C.bars.icon_size, default_border)
+        BarLayoutSize(pfUI.bars.shapeshift, NUM_SHAPESHIFT_SLOTS, C.bars.shapeshift.formfactor, C.bars.icon_size, default_border,shapeshiftbuttons)
         pfUI.bars.shapeshift:SetWidth(pfUI.bars.shapeshift._size[1])
         pfUI.bars.shapeshift:SetHeight(pfUI.bars.shapeshift._size[2])
         pfUI.bars.shapeshift:Show()


### PR DESCRIPTION
actionbars: Adjust layout size for dynamically spawned buttons. Fixes issues with shapeshift bar.

It makes it so the config option remains for the max possible buttons for each kind of bar, but it is now possible to shrink the layout to the minimum container the actual buttons spawned need to draw in.