### PR TITLE
Fixes #857 - Unitframes Vertical/Horizontal SetOrientation

### DIFF
--- a/api/unitframes.lua
+++ b/api/unitframes.lua
@@ -130,6 +130,8 @@ function pfUI.uf:UpdateConfig()
   f.hp.bar:SetAllPoints(f.hp)
   if f.config.verticalbar == "1" then
     f.hp.bar:SetOrientation("VERTICAL")
+  else
+    f.hp.bar:SetOrientation("HORIZONTAL")
   end
 
   if pfUI_config.unitframes.custombg == "1" then


### PR DESCRIPTION
correctly sets the Orientation of the Unitframes back to Horizontal
after changing it from vertical