### PR TITLE
Enhancement #854 - Module 'Durability' to move the Repair/Durability Frame

### DIFF
--- a/api/unitframes.lua
+++ b/api/unitframes.lua
@@ -130,6 +130,8 @@ function pfUI.uf:UpdateConfig()
   f.hp.bar:SetAllPoints(f.hp)
   if f.config.verticalbar == "1" then
     f.hp.bar:SetOrientation("VERTICAL")
+  else
+    f.hp.bar:SetOrientation("HORIZONTAL")
   end
 
   if pfUI_config.unitframes.custombg == "1" then

--- a/modules/durability.lua
+++ b/modules/durability.lua
@@ -1,0 +1,17 @@
+pfUI:RegisterModule("durability", function ()
+    
+    pfUI.durability = CreateFrame("Frame","pfDurability",UIParent)
+    pfUI.durability:SetPoint("TOPLEFT", pfUI.minimap, "BOTTOMLEFT", 0, -35)
+    UpdateMovable(pfUI.durability)
+    pfUI.durability:SetWidth(80)
+    pfUI.durability:SetHeight(70)
+    pfUI.durability:SetFrameStrata("BACKGROUND")
+    
+    pfUI.durability:SetScript("OnUpdate", function()
+        DurabilityFrame:SetParent(pfUI.durability)
+        DurabilityFrame:ClearAllPoints()
+        DurabilityFrame:SetPoint("CENTER", pfUI.durability)
+        DurabilityFrame:SetFrameLevel(1)
+        pfUI.durability:SetScript("OnUpdate", nil)
+    end)
+end)

--- a/pfUI.toc
+++ b/pfUI.toc
@@ -95,3 +95,4 @@ modules\hdgraphic.lua
 modules\share.lua
 modules\tracking.lua
 modules\easteregg.lua
+modules\durability.lua


### PR DESCRIPTION
I've created a module to make the DurabilityFrame moveable for enhancement request #854 .

I'd suggest making another parameter in the options menu like "Show Durability Frame" so that the user can select to hide the frame entirely. This could maybe be positioned at the options menu for the Minimap? I didn't want to make these adjustments without your input, maybe you have a better idea on where/how to position that.

The Frame itself is positioned by default at the bottom left of the minimap frame, below the "Zone Panel" with estimated the same distance from the frame to the Panel as the Panel has to the Minimap.