### PR TITLE
Implement an item breakdown on repair tooltip

### DIFF
--- a/api/api.lua
+++ b/api/api.lua
@@ -786,3 +786,27 @@ function pfUI.api.GetColoredTimeString(remaining)
     return ""
   end
 end
+
+-- [ GetColorGradient ] --
+-- 'perc'     percentage (0-1)
+-- 'colorMin' table or r,g,b tuple
+-- 'colorMax' table or r,g,b tuple
+-- return r,g,b and hexcolor
+function pfUI.api.GetColorGradient(perc, ...)
+  assert(tonumber(perc),"GetColorGradient: "..tostring(perc).." is not a number")
+  perc = pfUI.api.clamp(perc,0,1)
+  local c1, c2, r1,g1,b1, r2,g2,b2
+  if type(arg[1])=="table" then
+    c1,c2 = arg[1], arg[2]
+    r1,g1,b1 = c1[1] or c1.r, c1[2] or c1.g, c1[3] or c1.b
+    r2,g2,b2 = c2[1] or c2.r, c2[2] or c2.g, c2[3] or c2.b
+  elseif type(arg[1]=="number") then
+    r1,g1,b1 = arg[1], arg[2], arg[3]
+    r2,g2,b2 = arg[4], arg[5], arg[6]
+  end
+  if r1 and r2 and g1 and g2 and b1 and b2 then
+    local r,g,b = r1 + (r2-r1)*perc, g1 + (g2-g1)*perc, b1 + (b2-b1)*perc
+    local hex = string.format("|cff%02x%02x%02x", r*255, g*255, b*255)
+    return r,g,b,hex
+  end
+end

--- a/api/api.lua
+++ b/api/api.lua
@@ -107,6 +107,18 @@ function pfUI.api.clamp(x, min, max)
   end
 end
 
+-- [ modf ]
+-- Returns integral and fractional part of a number.
+-- 'f'          [float]        the number to breakdown.
+-- returns:     [int],[float]  whole and fractional part.
+function pfUI.api.modf(f)
+  if math.modf then return math.modf(f) end
+  if f > 0 then
+    return math.floor(f), math.mod(f,1)
+  end
+  return math.ceil(f), math.mod(f,1)
+end
+
 -- [ SanitizePattern ]
 -- Sanitizes and convert patterns into gfind compatible ones.
 -- 'pattern'    [string]         unformatted pattern
@@ -789,24 +801,61 @@ end
 
 -- [ GetColorGradient ] --
 -- 'perc'     percentage (0-1)
--- 'colorMin' table or r,g,b tuple
--- 'colorMax' table or r,g,b tuple
+-- 'color1' table or r,g,b tuple
+-- 'color2' table or r,g,b tuple
+-- ..
+-- 'colorN' table or r,g,b tuple
 -- return r,g,b and hexcolor
+local color_tuples = {}
 function pfUI.api.GetColorGradient(perc, ...)
-  assert(tonumber(perc),"GetColorGradient: "..tostring(perc).." is not a number")
+  local num = arg.n
+  local r,g,b,hex
+  assert(tonumber(perc), "GetColorGradient: "..tostring(perc).." is not a number")
+  assert((type(arg[1])=="number" and num>5) or (type(arg[1])=="table" and num>1), "GetColorGradient: needs at least 2 colors")
   perc = pfUI.api.clamp(perc,0,1)
-  local c1, c2, r1,g1,b1, r2,g2,b2
-  if type(arg[1])=="table" then
-    c1,c2 = arg[1], arg[2]
-    r1,g1,b1 = c1[1] or c1.r, c1[2] or c1.g, c1[3] or c1.b
-    r2,g2,b2 = c2[1] or c2.r, c2[2] or c2.g, c2[3] or c2.b
-  elseif type(arg[1]=="number") then
-    r1,g1,b1 = arg[1], arg[2], arg[3]
-    r2,g2,b2 = arg[4], arg[5], arg[6]
-  end
-  if r1 and r2 and g1 and g2 and b1 and b2 then
-    local r,g,b = r1 + (r2-r1)*perc, g1 + (g2-g1)*perc, b1 + (b2-b1)*perc
-    local hex = string.format("|cff%02x%02x%02x", r*255, g*255, b*255)
-    return r,g,b,hex
+  if type(arg[1])=="number" then -- called with r,g,b tuples
+    -- shortcircuit the edge cases
+    if perc == 1 then
+      r,g,b = arg[num-2], arg[num-1], arg[num]
+      hex = string.format("|cff%02x%02x%02x", r*255, g*255, b*255)
+      return r,g,b,hex
+    elseif perc == 0 then
+      r,g,b = arg[1], arg[2], arg[3]
+      hex = string.format("|cff%02x%02x%02x", r*255, g*255, b*255)
+      return r,g,b,hex
+    end
+    num = num/3
+    local segment, relativepercent = pfUI.api.modf(perc*(num-1))
+    local r1,g1,b1, r2,g2,b2
+    r1,g1,b1 = arg[segment*3+1], arg[segment*3+2], arg[segment*3+3]
+    r2,g2,b2 = arg[segment*3+4], arg[segment*3+5], arg[segment*3+6]
+    if not r2 or not g2 or not b2 then
+      r,g,b = r1,g1,b1
+      hex = string.format("|cff%02x%02x%02x", r*255, g*255, b*255)
+      return r,g,b,hex
+    else
+      r,g,b = r1 + (r2-r1)*relativepercent, g1 + (g2-g1)*relativepercent, b1 + (b2-b1)*relativepercent
+      hex = string.format("|cff%02x%02x%02x", r*255, g*255, b*255)
+      return r,g,b,hex
+    end
+  elseif type(arg[1])=="table" then -- called with color tables
+    -- shortcircuit the edge cases
+    if perc == 1 then
+      r,g,b = arg[num][1] or arg[num].r, arg[num][2] or arg[num].g, arg[num][3] or arg[num].b
+      hex = string.format("|cff%02x%02x%02x", r*255, g*255, b*255)
+      return r,g,b,hex
+    elseif perc == 0 then
+      r,g,b = arg[1][1] or arg[1].r, arg[1][2] or arg[1].g, arg[1][3] or arg[1].b
+      hex = string.format("|cff%02x%02x%02x", r*255, g*255, b*255)
+      return r,g,b,hex
+    end
+    pfUI.api.wipe(color_tuples)
+    for _,c in ipairs(arg) do
+      local r,g,b = c[1] or c.r, c[2] or c.g, c[3] or c.b
+      color_tuples[table.getn(color_tuples)+1] = r
+      color_tuples[table.getn(color_tuples)+1] = g
+      color_tuples[table.getn(color_tuples)+1] = b
+    end
+    return pfUI.api.GetColorGradient(perc,unpack(color_tuples))
   end
 end

--- a/modules/panel.lua
+++ b/modules/panel.lua
@@ -339,28 +339,38 @@ pfUI:RegisterModule("panel", function()
   end
 
   -- Update "durability"
+  local itemLines = {}
+  local slotnames = { "Head", "Shoulder", "Chest", "Wrist",
+      "Hands", "Waist", "Legs", "Feet", "MainHand", "SecondaryHand", "Ranged", }  
+  local totalRep = 0
   local repairToolTip = CreateFrame('GameTooltip', "repairToolTip", this, "GameTooltipTemplate")
   function pfUI.panel:UpdateRepair()
-    local slotnames = { "Head", "Shoulder", "Chest", "Wrist",
-      "Hands", "Waist", "Legs", "Feet", "MainHand", "SecondaryHand", "Ranged", }
     local repPercent = 100
     local lowestPercent = 100
-
+    totalRep = 0
+    wipe(itemLines)
     for i,slotName in pairs(slotnames) do
       local id, _ = GetInventorySlotInfo(slotName.. "Slot")
       repairToolTip:Hide()
       repairToolTip:SetOwner(this, "ANCHOR_LEFT")
-      local hasItem, _, _ = repairToolTip:SetInventoryItem("player", id)
+      local hasItem, _, repCost = repairToolTip:SetInventoryItem("player", id)
       if (not hasItem) then
         repairToolTip:ClearLines()
       else
-        for i=1, 30, 1 do
+        totalRep = totalRep + repCost
+        for i=1, 32, 1 do
           local tmpText = _G["repairToolTipTextLeft"..i]
           if (tmpText ~= nil) and (tmpText:GetText()) then
             local searchstr = string.gsub(DURABILITY_TEMPLATE, "%%[^%s]+", "(.+)")
             local _, _, lval, rval = string.find(tmpText:GetText(), searchstr, 1)
             if (lval and rval) then
               repPercent = math.floor(lval / rval * 100)
+              if repPercent < 100 then
+                local link = GetInventoryItemLink("player",id)
+                local r,g,b,hex = GetColorGradient(repPercent/100, 1,0,0, 0,1,0)
+                local cPercent = string.format("%s%s%%|r",hex,repPercent)
+                itemLines[table.getn(itemLines)+1]={link, cPercent}
+              end
               break
             end
           end
@@ -371,27 +381,18 @@ pfUI:RegisterModule("panel", function()
       end
     end
     repairToolTip:Hide()
-
+    
     local tooltip = function()
-      -- recalculate repair costs
-      local totalRep = 0
-        for i,slotName in pairs(slotnames) do
-          local id, _ = GetInventorySlotInfo(slotName.. "Slot")
-          repairToolTip:Hide()
-          repairToolTip:SetOwner(this, "ANCHOR_LEFT")
-          local hasItem, _, repCost = repairToolTip:SetInventoryItem("player", id)
-          totalRep = totalRep + repCost
-        end
-      repairToolTip:Hide()
-
-      -- show tooltip
       if totalRep > 0 then
         GameTooltip:ClearLines()
         GameTooltip_SetDefaultAnchor(GameTooltip, this)
         GameTooltip:SetText("|cff555555"..(string.gsub(REPAIR_COST,":","")).."|r")
         SetTooltipMoney(GameTooltip, totalRep)
+        for _,line in ipairs(itemLines) do
+          GameTooltip:AddDoubleLine(line[1],line[2])
+        end
         GameTooltip:Show()
-      end
+      end    
     end
 
     local click = function()

--- a/modules/panel.lua
+++ b/modules/panel.lua
@@ -367,7 +367,7 @@ pfUI:RegisterModule("panel", function()
               repPercent = math.floor(lval / rval * 100)
               if repPercent < 100 then
                 local link = GetInventoryItemLink("player",id)
-                local r,g,b,hex = GetColorGradient(repPercent/100, 1,0,0, 0,1,0)
+                local r,g,b,hex = GetColorGradient(repPercent/100, 1,0,0, 1,1,0, 0,1,0) -- red to green through yellow
                 local cPercent = string.format("%s%s%%|r",hex,repPercent)
                 itemLines[table.getn(itemLines)+1]={link, cPercent}
               end


### PR DESCRIPTION
Changelog  
api: GetColorGradient method to return a color c between color a and b given a ratio
panel: show damaged items on the repair tooltip with damage breakdown

Comments  
Some of the variables needed to be declared outside of the closure or they get "snapshotted" the first time the function returns [Ref:Closures](https://www.lua.org/pil/6.1.html)  

This also allows us to remove the 2nd loop over the inventory slots to get the repair cost for a small performance optimization.  

Credit to Lichery for starting the discussion with #905