### PR TITLE
Various Loot module improvements

### DIFF
--- a/api/api.lua
+++ b/api/api.lua
@@ -212,7 +212,11 @@ end
 function pfUI.api.SendChatMessageWide(msg)
   local channel = "SAY"
   if UnitInRaid("player") then
+    if ( IsRaidLeader() or IsRaidOfficer() ) then
+      channel = "RAID_WARNING"
+    else
     channel = "RAID"
+    end
   elseif UnitExists("party1") then
     channel = "PARTY"
   end

--- a/api/config.lua
+++ b/api/config.lua
@@ -94,6 +94,7 @@ function pfUI:LoadConfig()
   pfUI:UpdateConfig("loot",       nil,           "autopickup",       "1")
   pfUI:UpdateConfig("loot",       nil,           "mousecursor",      "1")
   pfUI:UpdateConfig("loot",       nil,           "advancedloot",     "1")
+  pfUI:UpdateConfig("loot",       nil,           "rollannounce",     "0")
   pfUI:UpdateConfig("loot",       nil,           "raritytimer",      "1")
 
   pfUI:UpdateConfig("unitframes", nil,           "disable",          "0")

--- a/env/translations_deDE.lua
+++ b/env/translations_deDE.lua
@@ -101,6 +101,7 @@ pfUI_translation["deDE"] = {
   ["Default"] = nil,
   ["Delete profile"] = nil,
   ["Delete / Reset"] = nil,
+  ["Detailed Random Roll Announcement"] = nil,
   ["Disable All UIErrors"] = nil,
   ["Disable Blizzard Castbar"] = nil,
   ["Disabled"] = nil,

--- a/env/translations_enUS.lua
+++ b/env/translations_enUS.lua
@@ -101,6 +101,7 @@ pfUI_translation["enUS"] = {
   ["Default"] = nil,
   ["Delete profile"] = nil,
   ["Delete / Reset"] = nil,
+  ["Detailed Random Roll Announcement"] = nil,
   ["Disable All UIErrors"] = nil,
   ["Disable Blizzard Castbar"] = nil,
   ["Disabled"] = nil,

--- a/env/translations_esES.lua
+++ b/env/translations_esES.lua
@@ -101,6 +101,7 @@ pfUI_translation["esES"] = {
   ["Default"] = "Por Defecto",
   ["Delete profile"] = "Borrar Perfil",
   ["Delete / Reset"] = "Borrar / Restablecer",
+  ["Detailed Random Roll Announcement"] = nil,
   ["Disable All UIErrors"] = "Desactivar los Errores de la IU",
   ["Disable Blizzard Castbar"] = "Desactivar la Barra de Lanzamiento de Blizzard",
   ["Disabled"] = "Desactivado",

--- a/env/translations_frFR.lua
+++ b/env/translations_frFR.lua
@@ -101,6 +101,7 @@ pfUI_translation["frFR"] = {
   ["Default"] = "Défaut",
   ["Delete profile"] = "Supprimer le profil",
   ["Delete / Reset"] = "Supprimer / Réinitialiser",
+  ["Detailed Random Roll Announcement"] = nil,
   ["Disable All UIErrors"] = "Désactiver tout les messages d'erreur liés à l'UI",
   ["Disable Blizzard Castbar"] = "Désactiver la barre d'incantation d'origine",
   ["Disabled"] = "Désactivé",

--- a/env/translations_koKR.lua
+++ b/env/translations_koKR.lua
@@ -101,6 +101,7 @@ pfUI_translation["koKR"] = {
   ["Default"] = "기본",
   ["Delete profile"] = "프로파일 삭제",
   ["Delete / Reset"] = "지우기/초기화",
+  ["Detailed Random Roll Announcement"] = nil,
   ["Disable"] = "가리기",
   ["Disable All UIErrors"] = "모든 UI오류 비활성화",
   ["Disable Blizzard Castbar"] = "블리자드 캐스트바 사용 중지",

--- a/env/translations_ruRU.lua
+++ b/env/translations_ruRU.lua
@@ -101,6 +101,7 @@ pfUI_translation["ruRU"] = {
   ["Default"] = "По умолчанию",
   ["Delete profile"] = "Удалить профиль",
   ["Delete / Reset"] = "Удалить / Сбросить",
+  ["Detailed Random Roll Announcement"] = nil,
   ["Disable All UIErrors"] = "Отключить все UI ошибки (красный текст сверху экрана)",
   ["Disable Blizzard Castbar"] = "Отключить панель применения Blizzard",
   ["Disabled"] = "Отключено",

--- a/env/translations_zhCN.lua
+++ b/env/translations_zhCN.lua
@@ -101,6 +101,7 @@ pfUI_translation["zhCN"] = {
   ["Default"] = "默认设置",
   ["Delete profile"] = "删除配置",
   ["Delete / Reset"] = "还原",
+  ["Detailed Random Roll Announcement"] = nil,
   ["Disable All UIErrors"] = "禁用所有UI错误",
   ["Disable Blizzard Castbar"] = "隐藏暴雪施法条",
   ["Disabled"] = "不显示",

--- a/env/translations_zhTW.lua
+++ b/env/translations_zhTW.lua
@@ -101,6 +101,7 @@ pfUI_translation["zhTW"] = {
   ["Default"] = "默認設置",
   ["Delete profile"] = "刪除配置",
   ["Delete / Reset"] = "還原",
+  ["Detailed Random Roll Announcement"] = nil,
   ["Disable All UIErrors"] = "禁用所有UI錯誤",
   ["Disable Blizzard Castbar"] = "隱藏暴雪施法條",
   ["Disabled"] = "不顯示",

--- a/modules/gui.lua
+++ b/modules/gui.lua
@@ -945,6 +945,7 @@ pfUI:RegisterModule("gui", function ()
       CreateConfig(nil, this, T["Disable Loot Confirmation Dialog (Without Group)"], C.loot, "autopickup", "checkbox")
       CreateConfig(nil, this, T["Enable Loot Window On MouseCursor"], C.loot, "mousecursor", "checkbox")
       CreateConfig(nil, this, T["Enable Advanced Master Loot Menu"], C.loot, "advancedloot", "checkbox")
+      CreateConfig(nil, this, T["Detailed Random Roll Announcement"], C.loot, "rollannounce", "checkbox")
       CreateConfig(nil, this, T["Use Item Rarity Color For Loot-Roll Timer"], C.loot, "raritytimer", "checkbox")
       this.setup = true
     end


### PR DESCRIPTION
**Changelog**  
loot: make detailed random roll announce an option, default: off
api: SendChatMessageWide will use raid warning if player is raid leader or assist
loot: rearrange advanced masterloot menus so random rolling and special recipients precede class menu
loot: fix a special recipients unitpopup menu check so they won't show in the context menu when the player is solo
loot: change the auto confirm bind when solo implementation, so player doesn't have to double-click the loot; also make sure it works if the loot bind confirmation staticpopup is not at index 1

**Comments**  
When I originally put in the random loot assign it was under the assumption that it will be used sparingly and in a PuG setting where announcing the full list of player and assigned number before doing the /roll and distributing is essential for trust.  
Since then quite a few people have reached out to tell me that it is also used as an alternative to auto-rollers for stuff like bijou / coins / scarabs etc so RLs can keep ML on the whole time and have someone just quickly random stuff.  
That makes the announce spam a problem.  
Additionally it's inconvenient for the person using the special menus frequently to have to traverse past the class menu to get to those options.  
So I re-arranged the menu to make random + special recipients more accessible and made the full random list announce an option.  
With the spam reduced or eliminated there was no more reason to not make SendChatMessageWide true to its name so it actually sends to the highest channel available according to player role.  

I also changed the implementation of the auto confirm BoP when solo because the previous one was forcing the player to double click the item to pick it up (the problem was two-fold: the static popup is shown by the default client through a registration in UIParent not LootFrame and that was never touched, pfUI was in addition trying to show the same static popup at the same event which due to it having the `exclusive = 1` flag set caused the UIParent one to hide and in essence clicked the 3rd static popup to show when the player clicked the loot slot again)