### PR TITLE
Loot: fix last comma in loot frame

### DIFF
--- a/modules/loot.lua
+++ b/modules/loot.lua
@@ -438,7 +438,7 @@ pfUI:RegisterModule("loot", function ()
           local color = ITEM_QUALITY_COLORS[quality]
 
           if(LootSlotIsCoin(id)) then
-            item = string.gsub(item,"\n", ", ")
+            item = string.gsub(string.gsub(item,"\n", ", "), ", $", "")
           end
 
           if(quantity > 1) then


### PR DESCRIPTION
now always in the name of the money at the end put a comma (see
screenshot). I fixed it.