### PR TITLE
Dropdown option in raid to set a player as tank

### DIFF
--- a/modules/raid.lua
+++ b/modules/raid.lua
@@ -39,30 +39,30 @@ pfUI:RegisterModule("raid", function ()
     end
   end
 
+  -- add units to the beginning of their groups
+  function pfUI.uf.raid:AddUnitToGroup(index, group)
+    for subindex = 1, 5 do
+      ids = subindex + 5*(group-1)
+      if pfUI.uf.raid[ids].id == 0 and pfUI.uf.raid[ids].config.visible == "1" then
+        pfUI.uf.raid[ids].id = index
+        pfUI.uf.raid[ids]:Show()
+        pfUI.uf:RefreshUnit(pfUI.uf.raid[ids], "all")
+        break
+      end
+    end
+  end
+
   function pfUI.uf.raid:RaidSetup()
     for i=1, 40 do
       pfUI.uf.raid[i].id = 0
       pfUI.uf.raid[i]:Hide()
     end
 
-    -- add units to the beginning of their groups
-    local function AddUnitToGroup(index, group)
-      for subindex = 1, 5 do
-        ids = subindex + 5*(group-1)
-        if pfUI.uf.raid[ids].id == 0 and pfUI.uf.raid[ids].config.visible == "1" then
-          pfUI.uf.raid[ids].id = index
-          pfUI.uf.raid[ids]:Show()
-          pfUI.uf:RefreshUnit(pfUI.uf.raid[ids], "all")
-          break
-        end
-      end
-    end
-
     -- sort tanks into their groups
     for i=1, GetNumRaidMembers() do
       local name, _, subgroup  = GetRaidRosterInfo(i)
       if name and pfUI.uf.raid.tankrole[name] then
-        AddUnitToGroup(i, subgroup)
+        pfUI.uf.raid:AddUnitToGroup(i, subgroup)
       end
     end
 
@@ -70,7 +70,7 @@ pfUI:RegisterModule("raid", function ()
     for i=1, GetNumRaidMembers() do
       local name, _, subgroup  = GetRaidRosterInfo(i)
       if name and not pfUI.uf.raid.tankrole[name] then
-        AddUnitToGroup(i, subgroup)
+        pfUI.uf.raid:AddUnitToGroup(i, subgroup)
       end
     end
   end

--- a/modules/raid.lua
+++ b/modules/raid.lua
@@ -9,6 +9,13 @@ pfUI:RegisterModule("raid", function ()
 
   pfUI.uf.raid = CreateFrame("Button","pfRaid",UIParent)
 
+  pfUI.uf.raid.tanksfirst = {
+    ["PF_TANK_TOGGLE"] = { T["Toggle as Tank"], "toggleTank" }
+  }
+
+  -- no tank order for now, just "all tanks first"
+  pfUI.uf.raid.tankrole = { }
+
   function pfUI.uf.raid:UpdateConfig()
     for i=1, 40 do
       pfUI.uf.raid[i]:UpdateConfig()
@@ -32,29 +39,63 @@ pfUI:RegisterModule("raid", function ()
     end
   end
 
-  pfUI.uf.raid:Hide()
-  pfUI.uf.raid:RegisterEvent("RAID_ROSTER_UPDATE")
-  pfUI.uf.raid:RegisterEvent("VARIABLES_LOADED")
-  pfUI.uf.raid:SetScript("OnEvent", function()
+  function pfUI.uf.raid:RaidSetup()
     for i=1, 40 do
       pfUI.uf.raid[i].id = 0
       pfUI.uf.raid[i]:Hide()
     end
 
+    -- add units to the beginning of their groups
+    local function AddUnitToGroup(index, group)
+      for subindex = 1, 5 do
+        ids = subindex + 5*(group-1)
+        if pfUI.uf.raid[ids].id == 0 and pfUI.uf.raid[ids].config.visible == "1" then
+          pfUI.uf.raid[ids].id = index
+          pfUI.uf.raid[ids]:Show()
+          pfUI.uf:RefreshUnit(pfUI.uf.raid[ids], "all")
+          break
+        end
+      end
+    end
+
+    -- sort tanks into their groups
+    for i=1, GetNumRaidMembers() do
+      local name, _, subgroup  = GetRaidRosterInfo(i)
+      if name and pfUI.uf.raid.tankrole[name] then
+        AddUnitToGroup(i, subgroup)
+      end
+    end
+
     -- sort players into roster
     for i=1, GetNumRaidMembers() do
       local name, _, subgroup  = GetRaidRosterInfo(i)
-      if name then
-        for subindex = 1, 5 do
-          ids = subindex + 5*(subgroup-1)
-          if pfUI.uf.raid[ids].id == 0 and pfUI.uf.raid[ids].config.visible == "1" then
-            pfUI.uf.raid[ids].id = i
-            pfUI.uf.raid[ids]:Show()
-            pfUI.uf:RefreshUnit(pfUI.uf.raid[ids], "all")
-            break
-          end
-        end
+      if name and not pfUI.uf.raid.tankrole[name] then
+        AddUnitToGroup(i, subgroup)
       end
+    end
+  end
+
+  pfUI.uf.raid:Hide()
+  pfUI.uf.raid:RegisterEvent("RAID_ROSTER_UPDATE")
+  pfUI.uf.raid:RegisterEvent("VARIABLES_LOADED")
+  pfUI.uf.raid:SetScript("OnEvent", function() pfUI.uf.raid:RaidSetup() end)
+
+  -- raid popup option to toggle tank role
+  local iupm = table.getn(UnitPopupMenus["RAID"])
+  for label, data in pairs(pfUI.uf.raid.tanksfirst) do
+    UnitPopupButtons[label] = { text = TEXT(data[1]), dist = 0 }
+    table.insert(UnitPopupMenus["RAID"], iupm-1, label)
+  end
+
+  hooksecurefunc("UnitPopup_OnClick", function()
+    local dropdownFrame = getglobal(UIDROPDOWNMENU_INIT_MENU)
+    local button = this.value
+    local unit = dropdownFrame.unit
+    local name = dropdownFrame.name
+
+    if button and pfUI.uf.raid.tanksfirst[button] and name then
+      pfUI.uf.raid.tankrole[name] = not pfUI.uf.raid.tankrole[name]
+      pfUI.uf.raid:RaidSetup()
     end
   end)
 end)


### PR DESCRIPTION
When you select someone as tank, he will be placed at the beginnig of his group, usefull for heals to see all tank in the same row/column.