### PR TITLE
pettarget: do not load module if pet frame is disabled

### DIFF
--- a/modules/pettarget.lua
+++ b/modules/pettarget.lua
@@ -1,6 +1,6 @@
 pfUI:RegisterModule("pettarget", function ()
   -- do not go further on disabled UFs
-  if C.unitframes.disable == "1" then return end
+  if C.unitframes.disable == "1" or pfUI.uf.pet == nil then return end
 
   local default_border = pfUI_config.appearance.border.default
   if pfUI_config.appearance.border.unitframes ~= "-1" then


### PR DESCRIPTION
got this error after updating to latest master:
![error_screen](https://i.imgur.com/uMI0051.png)

as i use LUF - i've disabled all frame modules