### PR TITLE
Fix questitem enchanting

### DIFF
--- a/modules/questitem.lua
+++ b/modules/questitem.lua
@@ -136,6 +136,8 @@ pfUI:RegisterModule("questitem", function ()
   pfUI.questitem.tooltip:SetScript("OnShow", function()
     if libtooltip:GetItemLink() then
       local id = libtooltip:GetItemID()
+      --fix-questitem-enchanting
+      if not id then return end
       local name = GetItemInfo(id)
       AddTooltip(GameTooltip, name)
     end


### PR DESCRIPTION
Fixes a bug when you hover mouse cursor over your enchanting recipes. With other professions didn't get any errors. 