### PR TITLE
xpbar: Added the option to not overlap the xpbar's rested bar to allow better color adjustment

### DIFF
--- a/api/config.lua
+++ b/api/config.lua
@@ -545,6 +545,7 @@ function pfUI:LoadConfig()
   pfUI:UpdateConfig("panel",      "xp",          "rep_mode",         "VERTICAL")
   pfUI:UpdateConfig("panel",      "xp",          "rep_anchor",       "pfChatRight")
   pfUI:UpdateConfig("panel",      "xp",          "rep_position",     "LEFT")
+  pfUI:UpdateConfig("panel",      "xp",          "dont_overlap",         "0")
 
   pfUI:UpdateConfig("castbar",    "player",      "hide_blizz",       "1")
   pfUI:UpdateConfig("castbar",    "player",      "hide_pfui",        "0")

--- a/env/translations_deDE.lua
+++ b/env/translations_deDE.lua
@@ -643,6 +643,7 @@ pfUI_translation["deDE"] = {
   ["Standard Text Font Size"] = nil,
   ["Status"] = nil,
   ["Status Bar Texture"] = nil,
+  ["Don't overlap rested"] = nil,
   ["Switch Pages On Druid Stealth"] = nil,
   ["Switch Pages On Meta Key Press"] = nil,
   ["Systeminfo"] = nil,

--- a/env/translations_enUS.lua
+++ b/env/translations_enUS.lua
@@ -643,6 +643,7 @@ pfUI_translation["enUS"] = {
   ["Standard Text Font Size"] = nil,
   ["Status"] = nil,
   ["Status Bar Texture"] = nil,
+  ["Don't overlap rested"] = nil,
   ["Switch Pages On Druid Stealth"] = nil,
   ["Switch Pages On Meta Key Press"] = nil,
   ["Systeminfo"] = nil,

--- a/env/translations_esES.lua
+++ b/env/translations_esES.lua
@@ -643,6 +643,7 @@ pfUI_translation["esES"] = {
   ["Standard Text Font Size"] = "Tamaño de la fuente de texto estándar",
   ["Status"] = "Estado",
   ["Status Bar Texture"] = "Textura de la barra de estado",
+  ["Don't overlap rested"] = nil,
   ["Switch Pages On Druid Stealth"] = "Alternar páginas en el modo sigilo del druida",
   ["Switch Pages On Meta Key Press"] = "Cambiar página por presionar la tecla meta",
   ["Systeminfo"] = "Información del sistema",

--- a/env/translations_frFR.lua
+++ b/env/translations_frFR.lua
@@ -643,6 +643,7 @@ pfUI_translation["frFR"] = {
   ["Standard Text Font Size"] = "Taille de la police standard du texte",
   ["Status"] = "Statut",
   ["Status Bar Texture"] = "Texture de la barre d'état",
+  ["Don't overlap rested"] = nil,
   ["Switch Pages On Druid Stealth"] = "Changer de page sur le camouflage du Druide",
   ["Switch Pages On Meta Key Press"] = "Basculer les pages sur la touche Meta",
   ["Systeminfo"] = "Info Système",

--- a/env/translations_koKR.lua
+++ b/env/translations_koKR.lua
@@ -643,6 +643,7 @@ pfUI_translation["koKR"] = {
   ["Standard Text Font Size"] = "기본 텍스트 폰트크기",
   ["Status"] = "상태",
   ["Status Bar Texture"] = nil,
+  ["Don't overlap rested"] = nil,
   ["Switch Pages On Druid Stealth"] = nil,
   ["Switch Pages On Meta Key Press"] = nil,
   ["Systeminfo"] = "시스템 정보",

--- a/env/translations_ruRU.lua
+++ b/env/translations_ruRU.lua
@@ -643,6 +643,7 @@ pfUI_translation["ruRU"] = {
   ["Standard Text Font Size"] = "Размер шрифта стандартного текста",
   ["Status"] = "Статус",
   ["Status Bar Texture"] = "Текстура статус панели",
+  ["Don't overlap rested"] = nil,
   ["Switch Pages On Druid Stealth"] = "Перекл страниц при невидимости друида",
   ["Switch Pages On Meta Key Press"] = "Перекл страниц по нажатию мета-клавиш (Alt, Shift, Ctrl)",
   ["Systeminfo"] = "Системная информация",

--- a/env/translations_zhCN.lua
+++ b/env/translations_zhCN.lua
@@ -643,6 +643,7 @@ pfUI_translation["zhCN"] = {
   ["Standard Text Font Size"] = "标准字体字号",
   ["Status"] = "当前状态",
   ["Status Bar Texture"] = "状态条纹理材质",
+  ["Don't overlap rested"] = nil,
   ["Switch Pages On Druid Stealth"] = nil,
   ["Switch Pages On Meta Key Press"] = "Ctrl/Alt/Shift 触发分页",
   ["Systeminfo"] = "系统信息",

--- a/env/translations_zhTW.lua
+++ b/env/translations_zhTW.lua
@@ -643,6 +643,7 @@ pfUI_translation["zhTW"] = {
   ["Standard Text Font Size"] = "標準字體字型大小",
   ["Status"] = "當前狀態",
   ["Status Bar Texture"] = "狀態條紋理材質",
+  ["Don't overlap rested"] = nil,
   ["Switch Pages On Druid Stealth"] = nil,
   ["Switch Pages On Meta Key Press"] = nil,
   ["Systeminfo"] = "系統資訊",

--- a/modules/gui.lua
+++ b/modules/gui.lua
@@ -1980,6 +1980,7 @@ pfUI:RegisterModule("gui", "vanilla:tbc", function ()
       CreateConfig(U["xpbar"], T["Orientation"], C.panel.xp, "xp_mode", "dropdown", pfUI.gui.dropdowns.orientation)
       CreateConfig(U["xpbar"], T["Frame Anchor"], C.panel.xp, "xp_anchor", "dropdown", pfUI.gui.dropdowns.xpanchors)
       CreateConfig(U["xpbar"], T["Aligned Position"], C.panel.xp, "xp_position", "dropdown", pfUI.gui.dropdowns.xp_position)
+      CreateConfig(U["xpbar"], T["Don't overlap rested"], C.panel.xp, "dont_overlap", "checkbox")
 
       CreateConfig(nil, T["Colors"], nil, nil, "header")
       CreateConfig(U["xpbar"], T["Experience Color"], C.panel.xp, "xp_color", "color")

--- a/modules/xpbar.lua
+++ b/modules/xpbar.lua
@@ -199,6 +199,14 @@ end
     b.position = t == "XP" and C.panel.xp.xp_position or C.panel.xp.rep_position
     b.display = t == "XP" and C.panel.xp.xp_display or C.panel.xp.rep_display
 
+    local barStrata = "LOW"
+    local restedStrata = "MEDIUM"
+    
+    if C.panel.xp.dont_overlap == "1" then
+      barStrata = "MEDIUM"
+      restedStrata = "LOW"
+    end
+
     if t == "XP" and C.panel.xp.xp_always == "1" then
       b.always = true
     elseif t == "REP" and C.panel.xp.rep_always == "1" then
@@ -220,7 +228,7 @@ end
     b.bar:SetStatusBarTexture(pfUI.media["img:bar"])
     b.bar:ClearAllPoints()
     b.bar:SetAllPoints(b)
-    b.bar:SetFrameStrata("LOW")
+    b.bar:SetFrameStrata(barStrata)
 
     local cr, cg, cb, ca = pfUI.api.GetStringColor(b.xp_color)
     b.bar:SetStatusBarColor(cr,cg,cb,ca)
@@ -230,7 +238,7 @@ end
     b.restedbar:SetStatusBarTexture(pfUI.media["img:bar"])
     b.restedbar:ClearAllPoints()
     b.restedbar:SetAllPoints(b)
-    b.restedbar:SetFrameStrata("MEDIUM")
+    b.restedbar:SetFrameStrata(restedStrata)
     local cr, cg, cb, ca = pfUI.api.GetStringColor(b.rest_color)
     b.restedbar:SetStatusBarColor(cr,cg,cb,ca)
     b.restedbar:SetOrientation(b.mode)


### PR DESCRIPTION
Currently, the xp bar's rested bar overlaps the actual xp bar which means that it is impossible to have a non-transparent rested color (as it would otherwise hide the xp bar [see images 1 and 2]). It also messes with the xp bar's color, as the rested bar's color will always be added ontop of it.

This pull request fixes this by adding a new option to push the rested bar below the xp bar, making only the actual rested part visible at the tail end of the player's current xp (see image 3). It is added as an option in order to not break already configured Interfaces and defaults to off.

Image 1 - The rested bar's transparency must always be below 100%
![01](https://user-images.githubusercontent.com/16930792/88683773-73b41200-d0f4-11ea-8bda-1273206c4319.png)

Image 2 - Transparency with 100% hides the xp bar
![02](https://user-images.githubusercontent.com/16930792/88683797-7adb2000-d0f4-11ea-9865-5b0cf0f4e6b0.png)

Image 3 - The bar with the new option enabled and a non transparent rested bar
![03](https://user-images.githubusercontent.com/16930792/88683808-7f073d80-d0f4-11ea-894f-f26d06841c2b.jpg)

I would appreciate any feedback!

Cheers