### PR TITLE
remove percent when displaying energy/rage/focus

### DIFF
--- a/api/unitframes.lua
+++ b/api/unitframes.lua
@@ -2179,7 +2179,10 @@ function pfUI.uf:GetStatusValue(unit, pos)
       return unit:GetColor("power") .. pfUI.api.Abbreviate(power)
     end
   elseif config == "powerdyn" then
-    if mp ~= mpmax then
+    -- dont show percentage for rage/energy/focus
+    if mpmax < 101 then
+      return unit:GetColor("power") .. "  " .. pfUI.api.Abbreviate(mp)
+    elseif mp ~= mpmax then
       return unit:GetColor("power") .. pfUI.api.Abbreviate(mp) .. " - " .. ceil(mp / mpmax * 100) .. "%"
     else
       return unit:GetColor("power") .. pfUI.api.Abbreviate(mp)

--- a/api/unitframes.lua
+++ b/api/unitframes.lua
@@ -2180,7 +2180,7 @@ function pfUI.uf:GetStatusValue(unit, pos)
     end
   elseif config == "powerdyn" then
     -- dont show percentage for rage/energy/focus
-    if mpmax == 100 then
+    if UnitPowerType(unitstr) > 0 then
       return unit:GetColor("power") .. pfUI.api.Abbreviate(mp)
     elseif mp ~= mpmax then
       return unit:GetColor("power") .. pfUI.api.Abbreviate(mp) .. " - " .. ceil(mp / mpmax * 100) .. "%"

--- a/api/unitframes.lua
+++ b/api/unitframes.lua
@@ -2179,10 +2179,8 @@ function pfUI.uf:GetStatusValue(unit, pos)
       return unit:GetColor("power") .. pfUI.api.Abbreviate(power)
     end
   elseif config == "powerdyn" then
-    -- dont show percentage for rage/energy/focus
-    if UnitPowerType(unitstr) > 0 then
-      return unit:GetColor("power") .. pfUI.api.Abbreviate(mp)
-    elseif mp ~= mpmax then
+    -- show percentage when only mana is less than 100%
+    elseif mp ~= mpmax and UnitPowerType(unitstr) == 0 then
       return unit:GetColor("power") .. pfUI.api.Abbreviate(mp) .. " - " .. ceil(mp / mpmax * 100) .. "%"
     else
       return unit:GetColor("power") .. pfUI.api.Abbreviate(mp)

--- a/api/unitframes.lua
+++ b/api/unitframes.lua
@@ -2180,7 +2180,7 @@ function pfUI.uf:GetStatusValue(unit, pos)
     end
   elseif config == "powerdyn" then
     -- dont show percentage for rage/energy/focus
-    if mpmax < 101 then --"mpmax == 100" wouldn't return true
+    if mpmax == 100 then
       return unit:GetColor("power") .. "  " .. pfUI.api.Abbreviate(mp)
     elseif mp ~= mpmax then
       return unit:GetColor("power") .. pfUI.api.Abbreviate(mp) .. " - " .. ceil(mp / mpmax * 100) .. "%"

--- a/api/unitframes.lua
+++ b/api/unitframes.lua
@@ -2181,7 +2181,7 @@ function pfUI.uf:GetStatusValue(unit, pos)
   elseif config == "powerdyn" then
     -- dont show percentage for rage/energy/focus
     if mpmax == 100 then
-      return unit:GetColor("power") .. "  " .. pfUI.api.Abbreviate(mp)
+      return unit:GetColor("power") .. pfUI.api.Abbreviate(mp)
     elseif mp ~= mpmax then
       return unit:GetColor("power") .. pfUI.api.Abbreviate(mp) .. " - " .. ceil(mp / mpmax * 100) .. "%"
     else

--- a/api/unitframes.lua
+++ b/api/unitframes.lua
@@ -2180,7 +2180,7 @@ function pfUI.uf:GetStatusValue(unit, pos)
     end
   elseif config == "powerdyn" then
     -- dont show percentage for rage/energy/focus
-    if mpmax < 101 then
+    if mpmax < 101 then --"mpmax == 100" wouldn't return true
       return unit:GetColor("power") .. "  " .. pfUI.api.Abbreviate(mp)
     elseif mp ~= mpmax then
       return unit:GetColor("power") .. pfUI.api.Abbreviate(mp) .. " - " .. ceil(mp / mpmax * 100) .. "%"


### PR DESCRIPTION
In powerdyn / "Mana - Auto" mode removes the percentage if mpmax is < 101 (i.e a energy/rage/focus bar) which can be off by 1 digit at times and look confusing (i.e energy looks like "35 - 36%")
also spaces the energy num display two spaces to the right for easier identification due to smaller number vs mana and clipping against rested icon
