### PR TITLE
Fix x and y coord update in frame unlock popup.

### DIFF
--- a/modules/unlock.lua
+++ b/modules/unlock.lua
@@ -597,11 +597,12 @@ pfUI:RegisterModule("unlock", "vanilla:tbc", function ()
   pfUI.unlock.dock.xcoord:SetFontObject(GameFontNormal)
   pfUI.unlock.dock.xcoord:SetAutoFocus(false)
 
-  pfUI.unlock.dock.xcoord:SetScript("OnEscapePressed", function(self)
-    if tonumber(this:GetText()) then
+  pfUI.unlock.dock.xcoord:SetScript("OnEnterPressed", function(self)
+    local newXPos = tonumber(this:GetText())
+    if newXPos then
       local frame = pfUI.unlock.dock.parent.frame
       local anchor, _, _, xpos, ypos = frame:GetPoint()
-      frame:SetPoint(anchor, xpos, ypos)
+      frame:SetPoint(anchor, newXPos, ypos)
       SavePosition(frame)
     else
       UpdateDockValues()
@@ -634,11 +635,12 @@ pfUI:RegisterModule("unlock", "vanilla:tbc", function ()
   pfUI.unlock.dock.ycoord:SetFontObject(GameFontNormal)
   pfUI.unlock.dock.ycoord:SetAutoFocus(false)
 
-  pfUI.unlock.dock.ycoord:SetScript("OnEscapePressed", function(self)
-    if tonumber(this:GetText()) then
+  pfUI.unlock.dock.ycoord:SetScript("OnEnterPressed", function(self)
+    local newYPos = tonumber(this:GetText())
+    if newYPos then
       local frame = pfUI.unlock.dock.parent.frame
       local anchor, _, _, xpos, ypos = frame:GetPoint()
-      frame:SetPoint(anchor, xpos, ypos)
+      frame:SetPoint(anchor, xpos, newYPos)
       SavePosition(frame)
     else
       UpdateDockValues()


### PR DESCRIPTION
Example: https://cdn.discordapp.com/attachments/695634717613228043/823649632633749514/unknown.png

You cannot actually edit those boxes. There are 2 things being wrong with it:
1. It awaits an "Escape" button press to modify value, seems counterintuitive, addons like ElvUI do that on Enter press.
2. It does not update values. SetPoint uses previous values, new value is never being used.

This fixes the boxes and mimics the ElvUI behavior for Enter button being the "save" action.