### PR TITLE
chat: fix tab text color

### DIFF
--- a/modules/chat.lua
+++ b/modules/chat.lua
@@ -403,7 +403,7 @@ pfUI:RegisterModule("chat", "vanilla:tbc", function ()
       end
 
       local _, class = UnitClass("player")
-      _G["ChatFrame" .. i .. "TabText"]:SetTextColor(RAID_CLASS_COLORS[class].r + .3 * .5, RAID_CLASS_COLORS[class].g + .3 * .5, RAID_CLASS_COLORS[class].b + .3 * .5, 1)
+      _G["ChatFrame" .. i .. "TabText"]:SetTextColor((RAID_CLASS_COLORS[class].r + .3) * .5, (RAID_CLASS_COLORS[class].g + .3) * .5, (RAID_CLASS_COLORS[class].b + .3) * .5, 1)
       _G["ChatFrame" .. i .. "TabText"]:SetFont(panelfont,panelfont_size, "OUTLINE")
 
       if _G["ChatFrame" .. i].isDocked or _G["ChatFrame" .. i]:IsVisible() then


### PR DESCRIPTION
The previous implementation looked like the intention was to use a slightly darker pastel version of the player's class color for the chat tab texts. But the parens around the addition were forgotten, which led to the tab text color bring brighter instead of darker, making it too intrusive.

Before:

![WoWScrnShot_122522_060936](https://user-images.githubusercontent.com/119806513/209458012-96c6b2aa-f747-43cf-9415-56431ab40c75.png)

After:

![fixed](https://user-images.githubusercontent.com/119806513/209458168-deb06698-14e5-4d11-b2e2-0cf379244e24.png)
