### PR TITLE
Skin Harcore Death & Super Macros button. Extending the game menu to fit.

### DIFF
--- a/modules/thirdparty-vanilla.lua
+++ b/modules/thirdparty-vanilla.lua
@@ -1095,6 +1095,15 @@ pfUI:RegisterModule("thirdparty-vanilla", "vanilla", function()
     SkinButton(GameMenuButtonAddOns)
   end)
 
+  HookAddonOrVariable("HardcoreDeath", function()
+    SkinButton(GameMenuButtonHardcoreDeathLogGUI)
+  end)
+  
+  HookAddonOrVariable("SuperMacro", function()
+    SkinButton(GameMenuButtonSuperMacro)
+  end)
+  
+
   HookAddonOrVariable("MacroExtender", function()
     -- Macro Extender moves the character dialog from frame-stata "dialog"
     -- to "low" and by that moves the frame below backgrounds, quest-trackers,

--- a/skins/blizzard/game_menu.lua
+++ b/skins/blizzard/game_menu.lua
@@ -7,7 +7,7 @@ pfUI:RegisterSkin("Game Menu", "vanilla:tbc", function ()
   if pfUI.expansion == 'tbc' then
     GameMenuFrame:SetHeight(GameMenuFrame:GetHeight() + 10)
   elseif pfUI.expansion == 'vanilla' then
-    GameMenuFrame:SetHeight(GameMenuFrame:GetHeight() + 6)
+    GameMenuFrame:SetHeight(GameMenuFrame:GetHeight() + 26)
   end
 
   local title = GetNoNameObject(GameMenuFrame, "FontString", "ARTWORK", MAIN_MENU)


### PR DESCRIPTION
Allowed pfUI to skin Hardcore Death Log and Super Macros.

Extending the main menu allowing the extra button.

![image](https://github.com/shagu/pfUI/assets/115322320/2009fa4e-d858-4918-95ee-6045f9026677)
