### PR TITLE
Update merchant.lua and Spellbook.lua - Merchant/Vendor and Spellbook mouse wheel page scrolling

### DIFF
--- a/skins/blizzard/merchant.lua
+++ b/skins/blizzard/merchant.lua
@@ -16,6 +16,23 @@ pfUI:RegisterSkin("Merchant", "vanilla:tbc", function ()
     MerchantRepairAllButton:ClearAllPoints()
     MerchantRepairAllButton:SetPoint("RIGHT", MerchantBuyBackItemItemButton, "LEFT", -6, 0)
   end
+  
+  --Merchant/vendor page mouse scrolling feature function
+  function MouseScrollCapability()
+    if (arg1 > 0) then
+      if (MerchantPrevPageButton:IsShown() and MerchantPrevPageButton:IsEnabled() == 1) then
+        MerchantPrevPageButton_OnClick()
+      end
+    elseif (arg1 < 0) then
+      if (MerchantNextPageButton:IsShown() and MerchantNextPageButton:IsEnabled() == 1) then
+        MerchantNextPageButton_OnClick()
+      end
+    end
+  end
+
+  --Enable mouse scrolling for merchant/vendor page switch
+  MerchantFrame:EnableMouseWheel(true)
+  MerchantFrame:SetScript("OnMouseWheel", MouseScrollCapability)
 
   StripTextures(MerchantFrame)
   CreateBackdrop(MerchantFrame, nil, nil, .75)

--- a/skins/blizzard/spellbook.lua
+++ b/skins/blizzard/spellbook.lua
@@ -63,4 +63,22 @@ pfUI:RegisterSkin("Spellbook", "vanilla:tbc", function ()
 
   SkinCloseButton(SpellBookCloseButton, SpellBookFrame.backdrop, -6, -6)
   SpellBookPageText:SetTextColor(1, 1, 1)
+  
+  --Spellbook page mouse scrolling feature function
+  function MouseScrollCapability()
+    if (arg1 > 0) then
+      if (SpellBookPrevPageButton:IsShown() and SpellBookPrevPageButton:IsEnabled() == 1) then
+        PrevPageButton_OnClick()
+      end
+    elseif (arg1 < 0) then
+      if (SpellBookNextPageButton:IsShown() and SpellBookNextPageButton:IsEnabled() == 1) then
+        NextPageButton_OnClick()
+      end
+    end
+  end
+  
+  --Enable mouse scrolling for spellbook page switch
+  SpellBookFrame:EnableMouseWheel(true)
+  SpellBookFrame:SetScript("OnMouseWheel", MouseScrollCapability)
+    
 end)


### PR DESCRIPTION
allow user to swap pages using mouse scrolling when the vendor or spellbook frames is open where there is more than 1 page

Feel free to edit as well.