### PR TITLE
mapcolors: rewrite module implementation

### DIFF
--- a/api/config.lua
+++ b/api/config.lua
@@ -178,6 +178,7 @@ function pfUI:LoadConfig()
   pfUI:UpdateConfig("appearance", "worldmap",    "mapreveal_color",  ".4,.4,.4,1")
   pfUI:UpdateConfig("appearance", "worldmap",    "mapexploration",   "0")
   pfUI:UpdateConfig("appearance", "worldmap",    "groupcircles",     "3")
+  pfUI:UpdateConfig("appearance", "worldmap",    "colornames",       "1")
 
   pfUI:UpdateConfig("loot",       nil,           "autoresize",       "1")
   pfUI:UpdateConfig("loot",       nil,           "autopickup",       "1")

--- a/env/translations_deDE.lua
+++ b/env/translations_deDE.lua
@@ -119,6 +119,7 @@ pfUI_translation["deDE"] = {
   ["Close"] = nil,
   ["Color Buff Stacks"] = nil,
   ["Color Debuff Stacks"] = nil,
+  ["Colorize player name on WorldMap and BattlefieldMinimap"] = nil,
   ["Colorize Unknown Classes"] = nil,
   ["Colors"] = nil,
   ["Combat"] = nil,

--- a/env/translations_enUS.lua
+++ b/env/translations_enUS.lua
@@ -119,6 +119,7 @@ pfUI_translation["enUS"] = {
   ["Close"] = nil,
   ["Color Buff Stacks"] = nil,
   ["Color Debuff Stacks"] = nil,
+  ["Colorize player name on WorldMap and BattlefieldMinimap"] = nil,
   ["Colorize Unknown Classes"] = nil,
   ["Colors"] = nil,
   ["Combat"] = nil,

--- a/env/translations_esES.lua
+++ b/env/translations_esES.lua
@@ -119,6 +119,7 @@ pfUI_translation["esES"] = {
   ["Close"] = "Cerrar",
   ["Color Buff Stacks"] = "Colorear pilas de beneficios",
   ["Color Debuff Stacks"] = "Colorear pilas de perjuicios",
+  ["Colorize player name on WorldMap and BattlefieldMinimap"] = nil,
   ["Colorize Unknown Classes"] = "Colorear clases desconocidas",
   ["Colors"] = "Colores",
   ["Combat"] = "Combate",

--- a/env/translations_frFR.lua
+++ b/env/translations_frFR.lua
@@ -119,6 +119,7 @@ pfUI_translation["frFR"] = {
   ["Close"] = "Fermer",
   ["Color Buff Stacks"] = "Couleur des l'empilements des Améliorations",
   ["Color Debuff Stacks"] = "Couleur de l'empilements de Affaiblissements",
+  ["Colorize player name on WorldMap and BattlefieldMinimap"] = nil,
   ["Colorize Unknown Classes"] = "Colorie les classes inconnues",
   ["Colors"] = "Couleurs",
   ["Combat"] = "Combat",

--- a/env/translations_koKR.lua
+++ b/env/translations_koKR.lua
@@ -119,6 +119,7 @@ pfUI_translation["koKR"] = {
   ["Close"] = "닫기",
   ["Color Buff Stacks"] = nil,
   ["Color Debuff Stacks"] = nil,
+  ["Colorize player name on WorldMap and BattlefieldMinimap"] = nil,
   ["Colorize Unknown Classes"] = nil,
   ["Colors"] = nil,
   ["Combat"] = "전투",

--- a/env/translations_ruRU.lua
+++ b/env/translations_ruRU.lua
@@ -119,6 +119,7 @@ pfUI_translation["ruRU"] = {
   ["Close"] = "Закрыть",
   ["Color Buff Stacks"] = "Цвет стаков баффа",
   ["Color Debuff Stacks"] = "Цвет стаков дебаффа",
+  ["Colorize player name on WorldMap and BattlefieldMinimap"] = "Раскрасить имена игроков на карте мира и миникарте поля боя",
   ["Colorize Unknown Classes"] = "Раскрасить неизвестные классы",
   ["Colors"] = "Цвета по умолчанию",
   ["Combat"] = "Бой",

--- a/env/translations_zhCN.lua
+++ b/env/translations_zhCN.lua
@@ -119,6 +119,7 @@ pfUI_translation["zhCN"] = {
   ["Close"] = "关闭",
   ["Color Buff Stacks"] = "Buff堆叠颜色",
   ["Color Debuff Stacks"] = "Debuff堆叠颜色",
+  ["Colorize player name on WorldMap and BattlefieldMinimap"] = nil,
   ["Colorize Unknown Classes"] = "有色未知职业",
   ["Colors"] = "颜色",
   ["Combat"] = "战斗报警",

--- a/env/translations_zhTW.lua
+++ b/env/translations_zhTW.lua
@@ -119,6 +119,7 @@ pfUI_translation["zhTW"] = {
   ["Close"] = "關閉",
   ["Color Buff Stacks"] = nil,
   ["Color Debuff Stacks"] = nil,
+  ["Colorize player name on WorldMap and BattlefieldMinimap"] = nil,
   ["Colorize Unknown Classes"] = "未知職業色彩",
   ["Colors"] = nil,
   ["Combat"] = "戰鬥報警",

--- a/modules/gui.lua
+++ b/modules/gui.lua
@@ -1518,6 +1518,7 @@ pfUI:RegisterModule("gui", "vanilla:tbc", function ()
       CreateConfig(U["mapreveal"], T["Map Reveal Color"], C.appearance.worldmap, "mapreveal_color", "color")
       CreateConfig(U["mapreveal"], T["Map Exploration Points"], C.appearance.worldmap, "mapexploration", "checkbox")
       CreateConfig(U["mapcolors"], T["Map Group/Raid Circle Size"], C.appearance.worldmap, "groupcircles", "dropdown", pfUI.gui.dropdowns.mapcircle)
+      CreateConfig(U["mapcolors"], T["Colorize player name on WorldMap and BattlefieldMinimap"], C.appearance.worldmap, "colornames", "checkbox")
       CreateConfig(U["map"], T["Map Tooltip Scale"], C.appearance.worldmap, "tooltipsize", "dropdown", pfUI.gui.dropdowns.maptooltip)
       CreateConfig(nil) -- spacer
       CreateConfig(nil, T["Enable Frame Shadow"], C.appearance.border, "shadow", "checkbox")


### PR DESCRIPTION
Completely rewrote the implementation of the module.
* **Fixed a bug with incorrect class colors determination.**
* Added coloring of nicknames when mouseover on frames. This feature can be disabled in the settings.
* The new implementation does not use OnUpdate all the time.

90% of the time the game is played, there is no need to update this data... Therefore, in the new implementation, the data is updated only when it is really necessary.
Data updating also works on OnUpdate, but now only when the WorldMapFrame and/or BattlefieldMinimap are displayed.

I tested and debugged everything for several days. There shouldn't be any problems