### PR TITLE
hoverbind: add support for mouse button & mouse wheel bindings

### DIFF
--- a/modules/actionbar.lua
+++ b/modules/actionbar.lua
@@ -1464,6 +1464,8 @@ pfUI:RegisterModule("actionbar", "vanilla:tbc", function ()
   pfUI.bars.update = updatecache
   pfUI.bars.buttons = buttoncache
   pfUI.bars.ButtonFullUpdate = ButtonFullUpdate
+  pfUI.bars.ButtonEnter = ButtonEnter
+  pfUI.bars.ButtonLeave = ButtonLeave
 
   pfUI.bars.UpdateGrid = function(self, state, typ)
     if not typ then

--- a/modules/hoverbind.lua
+++ b/modules/hoverbind.lua
@@ -36,6 +36,12 @@ pfUI:RegisterModule("hoverbind", "vanilla:tbc", function ()
     ["SHIFT"] = "SHIFT-"
   }
 
+  -- We don't allow binding these keys without any modifiers
+  local blockedKeys = {
+    "LeftButton",
+    "RightButton",
+  }
+
   pfUI.hoverbind = CreateFrame("Frame","pfKeyBindingFrame",UIParent)
   pfUI.hoverbind:Hide()
   pfUI.hoverbind:RegisterEvent("PLAYER_REGEN_DISABLED")
@@ -135,7 +141,15 @@ pfUI:RegisterModule("hoverbind", "vanilla:tbc", function ()
           local function GetHoverbindHandler(map)
             return function()
               if modifiers[arg1] then return end -- ignore single modifier keyup
-              if arg1 == "LeftButton" then return end -- Don't allow binding left mouse button
+
+              local prefix = pfUI.hoverbind:GetPrefix()
+
+              -- Don't allow binding certain buttons without modifiers
+              if not prefix or prefix == "" then
+                for _, blockedKey in ipairs(blockedKeys) do
+                  if arg1 == blockedKey then return end
+                end
+              end
 
               local frame = GetMouseFocus()
               local hovername = (frame and frame.button and frame.button.GetName) and frame.button:GetName() or ""
@@ -152,7 +166,7 @@ pfUI:RegisterModule("hoverbind", "vanilla:tbc", function ()
                 else 
                   -- Create new binding
                   local key = map and map[arg1] or arg1
-                  if (SetBinding(pfUI.hoverbind:GetPrefix() .. key, binding)) then
+                  if (SetBinding(prefix..key, binding)) then
                     SaveBindings(GetCurrentBindingSet())
                   end
                 end

--- a/modules/hoverbind.lua
+++ b/modules/hoverbind.lua
@@ -125,12 +125,12 @@ pfUI:RegisterModule("hoverbind", "vanilla:tbc", function ()
           frame:EnableKeyboard(true)
           frame:EnableMouse(true)
           frame:EnableMouseWheel(true)
-          frame:Hide();
+          frame:Hide()
 
           -- Store the actionbar button on the overlaying hoverbind frame so we can reference 
           -- them in the hoverbind handler to create the key/mouse binding. We need this
           -- because the hoverbind frames "steal" the mouse focus from the actual buttons.
-          frame.button = button;
+          frame.button = button
 
           local function GetHoverbindHandler(map)
             return function()

--- a/modules/hoverbind.lua
+++ b/modules/hoverbind.lua
@@ -36,8 +36,6 @@ pfUI:RegisterModule("hoverbind", "vanilla:tbc", function ()
     ["SHIFT"] = "SHIFT-"
   }
 
-  local need_save = false
-
   pfUI.hoverbind = CreateFrame("Frame","pfKeyBindingFrame",UIParent)
   pfUI.hoverbind:Hide()
   pfUI.hoverbind:RegisterEvent("PLAYER_REGEN_DISABLED")
@@ -147,17 +145,16 @@ pfUI:RegisterModule("hoverbind", "vanilla:tbc", function ()
                   local key = (GetBindingKey(binding))
                   if (key) then
                     SetBinding(key)
-                    need_save = true
+                    SaveBindings(GetCurrentBindingSet())
                   end
                 else 
                   -- Create new binding
                   local key = map and map[arg1] or arg1
                   if (SetBinding(pfUI.hoverbind:GetPrefix() .. key, binding)) then
-                    need_save = true
+                    SaveBindings(GetCurrentBindingSet())
                   end
                 end
               end
-              pfUI.hoverbind:SaveIfNeeded()
             end
           end
           frame:SetScript("OnKeyUp", GetHoverbindHandler())
@@ -181,14 +178,6 @@ pfUI:RegisterModule("hoverbind", "vanilla:tbc", function ()
     end
 
     return frames
-  end
-
-  -- if we set or cleared a binding save to the selected set
-  function pfUI.hoverbind:SaveIfNeeded()
-    if need_save then
-      need_save = false
-      SaveBindings(GetCurrentBindingSet())
-    end
   end
 
   function pfUI.hoverbind:ShowHoverbindFrames()

--- a/modules/hoverbind.lua
+++ b/modules/hoverbind.lua
@@ -135,6 +135,8 @@ pfUI:RegisterModule("hoverbind", "vanilla:tbc", function ()
           local function GetHoverbindHandler(map)
             return function()
               if modifiers[arg1] then return end -- ignore single modifier keyup
+              if arg1 == "LeftButton" then return end -- Don't allow binding left mouse button
+
               local frame = GetMouseFocus()
               local hovername = (frame and frame.button and frame.button.GetName) and frame.button:GetName() or ""
               local binding = pfUI.hoverbind:GetBinding(hovername)

--- a/modules/hoverbind.lua
+++ b/modules/hoverbind.lua
@@ -36,8 +36,6 @@ pfUI:RegisterModule("hoverbind", "vanilla:tbc", function ()
     ["SHIFT"] = "SHIFT-"
   }
 
-  -- TODO: Do we even need this? Can't we just always blindly save the bindings, even 
-  -- if there are no changes, or would that cause any (e.g. performance) issues?
   local need_save = false
 
   pfUI.hoverbind = CreateFrame("Frame","pfKeyBindingFrame",UIParent)


### PR DESCRIPTION
Fixes 🐭 #1016 and 🐁 #1127

# Summary

This extends hoverbind mode to allow binding mouse buttons and mouse wheel up/down to actionbar buttons. It does this by overlaying all actionbar buttons with separate invisible frames that receive all mouse and keyboard events and handle binding creation and removal.

# Versions Tested

Tested and everything seems to work fine on the following clients:

- 1.12.1 (5875)
- 1.17.1 (7100) (TurtleWoW)
- 2.4.3 (8606)

# Notes/Questions

1. Against my own expectations, I actually managed to make this work somehow... 😄 Thanks again for the ingame support last night @shagu! ❤️
2. Since I'm new to addon development, I'm not sure if this is the most elegant implementation. I'll let you be the judge and I'm looking forward to any kind of feedback.
3. ~~Do we even need the `need_save` variable & logic? The code would be nicer and simpler if we just always blindly `SaveBindings()`, even if there are no changes. Would that cause any (e.g. performance) issues?~~
**Update:** I removed this so we always just save bindings immediately. ([839a718](https://github.com/shagu/pfUI/pull/1269/commits/839a718bd5e6efc433515ce0ca8c5d304c8b018d))