### PR TITLE
#1294 [libcast.lua] The "CastSpell" post-hook should set the lastcasttex directly from the return arguments of libspell.GetSpellInfo()

### DIFF
--- a/libs/libcast.lua
+++ b/libs/libcast.lua
@@ -389,12 +389,14 @@ hooksecurefunc("UseContainerItem", function(id, index)
 end)
 
 hooksecurefunc("CastSpell", function(id, bookType)
-  _, lastrank = libspell.GetSpellInfo(id, bookType)
-  lastcasttex = GetSpellTexture(id, bookType)
+  local spellName, rank, texture, _, _, _, cachedId = libspell.GetSpellInfo(id, bookType)
+  if not spellName or not cachedId then return end -- ignore if the spell is not found
+
+  lastrank = rank
+  lastcasttex = texture
 
   if GetSpellCooldown(id, bookType) ~= 0 then
-    local spellName = GetSpellName(id, bookType)
-    CastCustom(spellName)
+    CastCustom(spellName) 
   end
 end, true)
 


### PR DESCRIPTION
https://github.com/shagu/pfUI/issues/1294