### PR TITLE
libspell: Searching GetSpellIndex("Holy Light", "Rank 3") and then searching for GetSpellIndex("Holy Light(Rank 3)") should result in a cache-hit the second time around but it doesn't

### DIFF
--- a/libs/libspell.lua
+++ b/libs/libspell.lua
@@ -46,8 +46,8 @@ end
 -- return:      [number],[string]   spell index and spellbook id
 local spellindex = {}
 function libspell.GetSpellIndex(name, rank)
-  local name = string.lower(name)
-  local cache = spellindex[name..(rank or "")]
+  name = string.lower(name)
+  local cache = spellindex[name..(rank and ("("..rank..")") or "")]
   if cache then return cache[1], cache[2] end
 
   if not rank then rank = libspell.GetSpellMaxRank(name) end
@@ -58,7 +58,7 @@ function libspell.GetSpellIndex(name, rank)
     for id = offset + 1, offset + num do
       local spellName, spellRank = GetSpellName(id, bookType)
       if rank and rank == spellRank and name == string.lower(spellName) then
-        spellindex[name..rank] = { id, bookType }
+        spellindex[name.."("..rank..")"] = { id, bookType }
         return id, bookType
       elseif not rank and name == string.lower(spellName) then
         spellindex[name] = { id, bookType }
@@ -67,7 +67,7 @@ function libspell.GetSpellIndex(name, rank)
     end
   end
 
-  spellindex[name..(rank or "")] = { nil }
+  spellindex[name..(rank and ("("..rank..")") or "")] = { nil }
   return nil
 end
 


### PR DESCRIPTION
The culprit lies in the way we store/seek spells in the cache. We are currently storing:

```lua
spellindex[name..(rank or "")]
```

But we should be storing:

```lua
spellindex[name..(rank and ("("..rank..")") or "")]
```

