### PR TITLE
[Loot] Fix infinite loop autopickup. replace with delayed ConfirmLootSlot()

### DIFF
--- a/modules/loot.lua
+++ b/modules/loot.lua
@@ -715,7 +715,7 @@ pfUI:RegisterModule("loot", "vanilla:tbc", function ()
         local slot = arg1
         QueueFunction(function()
           ConfirmLootSlot(slot)
-		      StaticPopup_Hide("LOOT_BIND")
+          StaticPopup_Hide("LOOT_BIND")
         end)
       elseif event == "LOOT_OPENED" and pfUI.client <= 11200 then
         for i=1,GetNumLootItems() do

--- a/modules/loot.lua
+++ b/modules/loot.lua
@@ -712,7 +712,7 @@ pfUI:RegisterModule("loot", "vanilla:tbc", function ()
     -- auto accept BoP loot in solo mode
     if C.loot.autopickup == "1" and GetNumPartyMembers() == 0 and GetNumRaidMembers() == 0 then
       if event == "LOOT_BIND_CONFIRM" then
-          pfUI.api.QueueFunction(ConfirmLootSlot, arg1)
+        pfUI.api.QueueFunction(ConfirmLootSlot, arg1)
       elseif event == "LOOT_OPENED" and pfUI.client <= 11200 then
         for i=1,GetNumLootItems() do
           LootSlot(i)

--- a/modules/loot.lua
+++ b/modules/loot.lua
@@ -712,7 +712,11 @@ pfUI:RegisterModule("loot", "vanilla:tbc", function ()
     -- auto accept BoP loot in solo mode
     if C.loot.autopickup == "1" and GetNumPartyMembers() == 0 and GetNumRaidMembers() == 0 then
       if event == "LOOT_BIND_CONFIRM" then
-        pfUI.api.QueueFunction(ConfirmLootSlot, arg1)
+        local slot = arg1
+	      QueueFunction(function()
+		      ConfirmLootSlot(slot)
+		      StaticPopup_Hide("LOOT_BIND")
+		    end)
       elseif event == "LOOT_OPENED" and pfUI.client <= 11200 then
         for i=1,GetNumLootItems() do
           LootSlot(i)

--- a/modules/loot.lua
+++ b/modules/loot.lua
@@ -713,10 +713,10 @@ pfUI:RegisterModule("loot", "vanilla:tbc", function ()
     if C.loot.autopickup == "1" and GetNumPartyMembers() == 0 and GetNumRaidMembers() == 0 then
       if event == "LOOT_BIND_CONFIRM" then
         local slot = arg1
-	      QueueFunction(function()
-		      ConfirmLootSlot(slot)
+        QueueFunction(function()
+          ConfirmLootSlot(slot)
 		      StaticPopup_Hide("LOOT_BIND")
-		    end)
+        end)
       elseif event == "LOOT_OPENED" and pfUI.client <= 11200 then
         for i=1,GetNumLootItems() do
           LootSlot(i)

--- a/modules/loot.lua
+++ b/modules/loot.lua
@@ -712,8 +712,7 @@ pfUI:RegisterModule("loot", "vanilla:tbc", function ()
     -- auto accept BoP loot in solo mode
     if C.loot.autopickup == "1" and GetNumPartyMembers() == 0 and GetNumRaidMembers() == 0 then
       if event == "LOOT_BIND_CONFIRM" then
-        LootSlot(arg1)
-        StaticPopup1Button1:Click()
+          pfUI.api.QueueFunction(ConfirmLootSlot, arg1)
       elseif event == "LOOT_OPENED" and pfUI.client <= 11200 then
         for i=1,GetNumLootItems() do
           LootSlot(i)


### PR DESCRIPTION
Could not avoid the delay.
Instead of clicking accept and risk clicking wrong popup, just use the proper confirm and close the dialog

tested only 2.4.3