### PR TITLE
Added total line to gold info panel.  Added (rough) translations.

### DIFF
--- a/env/translations_deDE.lua
+++ b/env/translations_deDE.lua
@@ -713,6 +713,7 @@ pfUI_translation["deDE"] = {
   ["Thick Outline"] = nil,
   ["Thirdparty"] = nil,
   ["This Session"] = nil,
+  ["Total Gold"] = nil,
   ["Threshold To Trust Health Estimation"] = nil,
   ["Time"] = nil,
   ["Timer"] = nil,

--- a/env/translations_enUS.lua
+++ b/env/translations_enUS.lua
@@ -713,6 +713,7 @@ pfUI_translation["enUS"] = {
   ["Thick Outline"] = nil,
   ["Thirdparty"] = nil,
   ["This Session"] = nil,
+  ["Total Gold"] = nil,
   ["Threshold To Trust Health Estimation"] = nil,
   ["Time"] = nil,
   ["Timer"] = nil,

--- a/env/translations_esES.lua
+++ b/env/translations_esES.lua
@@ -713,6 +713,7 @@ pfUI_translation["esES"] = {
   ["Thick Outline"] = "Contorno grueso",
   ["Thirdparty"] = "Terceros",
   ["This Session"] = "Esta sesión",
+  ["Total Gold"] = "Oro Total",
   ["Threshold To Trust Health Estimation"] = "Umbral para confiar en la estimación de salud",
   ["Time"] = "Tiempo",
   ["Timer"] = "Temporizador",

--- a/env/translations_frFR.lua
+++ b/env/translations_frFR.lua
@@ -713,6 +713,7 @@ pfUI_translation["frFR"] = {
   ["Thick Outline"] = "Contour épais",
   ["Thirdparty"] = "Autres addons",
   ["This Session"] = "Session Actuelle",
+  ["Total Gold"] = "Or Total",
   ["Threshold To Trust Health Estimation"] = "Seuil de confiance pour l'estimation de la santé",
   ["Time"] = "Heure",
   ["Timer"] = nil,

--- a/env/translations_koKR.lua
+++ b/env/translations_koKR.lua
@@ -712,6 +712,7 @@ pfUI_translation["koKR"] = {
   ["Thick Outline"] = nil,
   ["Thirdparty"] = "서드파티",
   ["This Session"] = "이번 세션",
+  ["Total Gold"] = "총 금",
   ["Threshold To Trust Health Estimation"] = nil,
   ["Time"] = "시간",
   ["Timer"] = nil,

--- a/env/translations_ruRU.lua
+++ b/env/translations_ruRU.lua
@@ -713,6 +713,7 @@ pfUI_translation["ruRU"] = {
   ["Thick Outline"] = "Толстый контурный", -- font style
   ["Thirdparty"] = "Другие аддоны",
   ["This Session"] = "Эта сессия",
+  ["Total Gold"] = "Всего золота",
   ["Threshold To Trust Health Estimation"] = "Точность подсчетов здоровья",
   ["Time"] = "Время",
   ["Timer"] = "Таймер",

--- a/env/translations_zhCN.lua
+++ b/env/translations_zhCN.lua
@@ -715,6 +715,7 @@ pfUI_translation["zhCN"] = {
   ["Thick Outline"] = "粗轮廓",
   ["Thirdparty"] = "第三方插件接口",
   ["This Session"] = "本次登录收益",
+  ["Total Gold"] = "总黄金",
   ["Threshold To Trust Health Estimation"] = "信任生命值预估的阈值",
   ["Time"] = "时间",
   ["Timer"] = "计时器",

--- a/env/translations_zhTW.lua
+++ b/env/translations_zhTW.lua
@@ -713,6 +713,7 @@ pfUI_translation["zhTW"] = {
   ["Thick Outline"] = nil,
   ["Thirdparty"] = "協力廠商外掛程式介面",
   ["This Session"] = "本次登錄收益",
+  ["Total Gold"] = "總金量",
   ["Threshold To Trust Health Estimation"] = nil,
   ["Time"] = "計時器",
   ["Timer"] = nil,

--- a/modules/panel.lua
+++ b/modules/panel.lua
@@ -277,13 +277,16 @@ pfUI:RegisterModule("panel", "vanilla:tbc", function()
         GameTooltip:AddDoubleLine(T["Login"] .. ":", CreateGoldString(pfUI.panel.initMoney))
         GameTooltip:AddDoubleLine(T["Now"] .. ":", CreateGoldString(GetMoney()))
         GameTooltip:AddDoubleLine("|cffffffff","")
+        local totalgold = 0
         for name, gold in pairs(pfUI_cache["gold"][GetRealmName()]) do
+          totalgold = totalgold + gold
           if name ~= UnitName("player") then
             GameTooltip:AddDoubleLine(name .. ":", CreateGoldString(gold))
           end
         end
         GameTooltip:AddDoubleLine("|cffffffff","")
         GameTooltip:AddDoubleLine(T["This Session"] .. ":", dmod .. CreateGoldString(math.abs(pfUI.panel.diffMoney)))
+        GameTooltip:AddDoubleLine(T["Total Gold"] .. ":", dmod .. CreateGoldString(totalgold))
         GameTooltip:Show()
       end
       widget:SetScript("OnEvent", function()

--- a/modules/panel.lua
+++ b/modules/panel.lua
@@ -286,7 +286,7 @@ pfUI:RegisterModule("panel", "vanilla:tbc", function()
         end
         GameTooltip:AddDoubleLine("|cffffffff","")
         GameTooltip:AddDoubleLine(T["This Session"] .. ":", dmod .. CreateGoldString(math.abs(pfUI.panel.diffMoney)))
-        GameTooltip:AddDoubleLine(T["Total Gold"] .. ":", dmod .. CreateGoldString(totalgold))
+        GameTooltip:AddDoubleLine(T["Total Gold"] .. ":", CreateGoldString(totalgold))
         GameTooltip:Show()
       end
       widget:SetScript("OnEvent", function()


### PR DESCRIPTION
The information layout on the gold tooltip makes it hard to quickly add up your total gold across characters with a quick glance.  Added a total line so I didn't have to do the math.  Most of the German translations were set to nil so I added the same, the others are rough machine translations.