### PR TITLE
turtle-wow: update Immolate duration after cast Conflagrate

### DIFF
--- a/libs/libdebuff.lua
+++ b/libs/libdebuff.lua
@@ -61,6 +61,15 @@ function libdebuff:GetDuration(effect, rank)
   end
 end
 
+function libdebuff:UpdateDuration(unit, unitlevel, effect, duration)
+  if not unit or not effect or not duration then return end
+  unitlevel = unitlevel or 0
+
+  if libdebuff.objects[unit] and libdebuff.objects[unit][unitlevel] and libdebuff.objects[unit][unitlevel][effect] then
+    libdebuff.objects[unit][unitlevel][effect].duration = duration
+  end
+end
+
 function libdebuff:GetMaxRank(effect)
   local max = 0
   for id in pairs(L["debuffs"][effect]) do

--- a/modules/turtle-wow.lua
+++ b/modules/turtle-wow.lua
@@ -41,14 +41,13 @@ pfUI:RegisterModule("turtle-wow", "vanilla", function ()
       WorldMapFrameTitle:Hide()
     end
 
-    -- refresh paladin judgements on holy strike
-    -- taken from: https://github.com/doorknob6/pfUI-turtle/blob/master/modules/debuffs.lua
     HookScript(libdebuff, "OnEvent", function()
       if event == "CHAT_MSG_SPELL_SELF_DAMAGE" then
-        local spell = string.find(string.sub(arg1,6,17), "Holy Strike")
-
-        --arg2 is holy dmg when it hits, nil when it misses
-        if spell and arg2 then
+        -- refresh paladin judgements on holy strike
+        -- taken from: https://github.com/doorknob6/pfUI-turtle/blob/master/modules/debuffs.lua
+        local holystrike = string.find(string.sub(arg1,6,17), "Holy Strike")
+        --arg2 is spell dmg when it hits, nil when it misses
+        if holystrike and arg2 then
           for seal in L["judgements"] do
             local name = UnitName("target")
             local level = UnitLevel("target")
@@ -63,6 +62,16 @@ pfUI:RegisterModule("turtle-wow", "vanilla", function ()
               end
             end
           end
+        end
+
+        -- refresh Immolate duration after cast Conflagrate
+        local conflagrate = string.find(string.sub(arg1,6,17), "Conflagrate")
+        --arg2 is spell dmg when it hits, nil when it misses
+        if conflagrate and arg2 then
+          local name = UnitName("target")
+          local level = UnitLevel("target")
+          local duration = libdebuff.objects[name][level]["Immolate"].duration
+          libdebuff:UpdateDuration(name, level, "Immolate", duration - 3)
         end
       end
     end)

--- a/modules/turtle-wow.lua
+++ b/modules/turtle-wow.lua
@@ -70,8 +70,10 @@ pfUI:RegisterModule("turtle-wow", "vanilla", function ()
         if conflagrate and arg2 then
           local name = UnitName("target")
           local level = UnitLevel("target")
-          local duration = libdebuff.objects[name][level]["Immolate"].duration
-          libdebuff:UpdateDuration(name, level, "Immolate", duration - 3)
+          if libdebuff.objects[name][level]["Immolate"] then
+            local duration = libdebuff.objects[name][level]["Immolate"].duration
+            libdebuff:UpdateDuration(name, level, "Immolate", duration - 3)
+          end
         end
       end
     end)


### PR DESCRIPTION
In 1.17.2 TW devs change Conflagrate. Now it consumes 3 sec Immolate.
You can read new talent description here:
https://talents.turtle-wow.org/warlock