### PR TITLE
castbar: set strata to high so it can overlap unitframes

### DIFF
--- a/modules/castbar.lua
+++ b/modules/castbar.lua
@@ -8,7 +8,7 @@ pfUI:RegisterModule("castbar", "vanilla:tbc", function ()
     local cb = CreateFrame("Frame", name, parent or UIParent)
 
     cb:SetHeight(C.global.font_size * 1.5)
-    cb:SetFrameStrata("MEDIUM")
+    cb:SetFrameStrata("HIGH")
 
     cb.unitstr = unitstr
     cb.unitname = unitname


### PR DESCRIPTION
Increase castbar frame strata so it's able to overlap unitframes again.

I positioned the castbar on top of my unitframes to simulate it replacing the powerbar. That was broken in commit [afba5f](https://github.com/shagu/pfUI/commit/afba5fe60bed6dab5095a5272e1328f829512a73) and this PR fixes it again.

![pfui-castbar-fix](https://github.com/user-attachments/assets/7ac80f72-f9d0-49f0-a790-f6b7591bece0)