### PR TITLE
Fixed pet happiness & totems for Totemic Recall

### DIFF
--- a/api/unitframes.lua
+++ b/api/unitframes.lua
@@ -1411,7 +1411,7 @@ function pfUI.uf:RefreshIndicators(unit)
   end
 
   if unit.happinessIcon and unit:GetName() == "pfPet" then -- Happiness Icon
-    if unit.config.happinessicon == "0" then
+    if unit.config.happinessicon == "0" or UnitClass("player") == "Warlock" then
       unit.happinessIcon:Hide()
     else
       if UnitIsVisible("pet") then

--- a/libs/libtotem.lua
+++ b/libs/libtotem.lua
@@ -83,8 +83,12 @@ local totems = {
   },
 }
 
-GetTotemInfo = function(id)
+GetTotemInfo = function(id, totrecall)
   if not active[id] or not active[id].name then return end
+  if totrecall then
+    libtotem:Clean(id)
+    return nil
+  end
   if active[id].start + active[id].duration - GetTime() < 0 then
     libtotem:Clean(id)
     return nil

--- a/modules/totems.lua
+++ b/modules/totems.lua
@@ -11,8 +11,17 @@ pfUI:RegisterModule("totems", "vanilla:tbc", function ()
   local totems = CreateFrame("Frame", "pfTotems", UIParent)
   totems:RegisterEvent("PLAYER_TOTEM_UPDATE")
   totems:RegisterEvent("PLAYER_ENTERING_WORLD")
+  totems:RegisterEvent("CHAT_MSG_SPELL_SELF_BUFF")
   totems:SetScript("OnEvent", function(self)
-    totems:RefreshList()
+    if arg1 then
+      -- Check if the message contains the specific phrase related to Totemic Recall
+      if string.find(arg1, "You gain") and string.find(arg1, "Mana from Totemic Recall") then
+        totems:RefreshList(true)
+      end
+    else
+      -- Handle the case where there's no specific event
+      totems:RefreshList()
+    end
   end)
 
   if pfUI.client <= 11200 and class == "SHAMAN" then
@@ -48,9 +57,12 @@ pfUI:RegisterModule("totems", "vanilla:tbc", function ()
     end
   end
 
-  totems.RefreshList = function(self)
+  totems.RefreshList = function(self, totrecall)
     local count = 0
     for i = 1, MAX_TOTEMS do
+      if totrecall then
+        GetTotemInfo(i, totrecall)
+      end
       local active, name, start, duration, icon = GetTotemInfo(i)
 
       if active and icon and icon ~= "" then
@@ -61,11 +73,10 @@ pfUI:RegisterModule("totems", "vanilla:tbc", function ()
         self.bar[count]:SetBackdropBorderColor(color.r, color.g, color.b)
         self.bar[count].icon:SetTexture(icon)
         self.bar[count].id = i
-
+  
         CooldownFrame_SetTimer(self.bar[count].cd, start, duration, 1)
       end
     end
-
     self:UpdateSize(count)
   end
 

--- a/pfUI.toc
+++ b/pfUI.toc
@@ -4,8 +4,8 @@
 ## Notes: A complete user interface replacement.
 ## Notes-ruRU: Полная замена пользовательского интерфейса.
 ## Version: 5.4.11
-## SavedVariables: pfUI_profiles, pfUI_addon_profiles, pfUI_cache
-## SavedVariablesPerCharacter: pfUI_config, pfUI_init, pfUI_playerDB
+## SavedVariables: pfUI_profiles, pfUI_addon_profiles, pfUI_init
+## SavedVariablesPerCharacter: pfUI_playerDB, pfUI_config, pfUI_cache
 
 pfUI.lua
 

--- a/pfUI.toc
+++ b/pfUI.toc
@@ -4,8 +4,8 @@
 ## Notes: A complete user interface replacement.
 ## Notes-ruRU: Полная замена пользовательского интерфейса.
 ## Version: 5.4.11
-## SavedVariables: pfUI_profiles, pfUI_addon_profiles, pfUI_init
-## SavedVariablesPerCharacter: pfUI_playerDB, pfUI_config, pfUI_cache
+## SavedVariables: pfUI_profiles, pfUI_addon_profiles, pfUI_cache
+## SavedVariablesPerCharacter: pfUI_config, pfUI_init, pfUI_playerDB
 
 pfUI.lua
 


### PR DESCRIPTION
Probably a better way to handle the totems. Pet happiness all I did was disable for warlock.