### PR TITLE
map: ensure strata is fullscreen

### DIFF
--- a/modules/map.lua
+++ b/modules/map.lua
@@ -39,6 +39,7 @@ pfUI:RegisterModule("map", "vanilla:tbc", function ()
 
     UIPanelWindows["WorldMapFrame"] = { area = "center" }
 
+    WorldMapFrame:SetFrameStrata("FULLSCREEN")
     WorldMapFrame:SetMovable(true)
     WorldMapFrame:EnableMouse(true)
     WorldMapFrame:RegisterForDrag("LeftButton")


### PR DESCRIPTION
This fixes a minor issue encountered on the Turtle WoW server, where switching from a windowed map to using pfUI caused the strata to be set to medium until the UI was reloaded.