### PR TITLE
pet happiness for hunter only

### DIFF
--- a/api/unitframes.lua
+++ b/api/unitframes.lua
@@ -1411,7 +1411,7 @@ function pfUI.uf:RefreshIndicators(unit)
   end
 
   if unit.happinessIcon and unit:GetName() == "pfPet" then -- Happiness Icon
-    if unit.config.happinessicon == "0" then
+    if unit.config.happinessicon == "0" or UnitClass("player") ~= "Hunter" then
       unit.happinessIcon:Hide()
     else
       if UnitIsVisible("pet") then


### PR DESCRIPTION
Added check to verify player class to prevent pet happiness indicator outside of Hunter's.