### PR TITLE
Overwrite nameplate color and border with agro state

### DIFF
--- a/api/config.lua
+++ b/api/config.lua
@@ -725,6 +725,7 @@ function pfUI:LoadConfig()
   pfUI:UpdateConfig("nameplates", nil,           "totemicons",       "0")
   pfUI:UpdateConfig("nameplates", nil,           "showguildname",    "0")
 
+  pfUI:UpdateConfig("nameplates", nil,           "agrostate",        "0")
   pfUI:UpdateConfig("nameplates", nil,           "outcombatstate",   "1")
   pfUI:UpdateConfig("nameplates", nil,           "outfriendly",      "0")
   pfUI:UpdateConfig("nameplates", nil,           "outfriendlynpc",   "1")

--- a/modules/gui.lua
+++ b/modules/gui.lua
@@ -2285,6 +2285,7 @@ pfUI:RegisterModule("gui", "vanilla:tbc", function ()
       CreateConfig(U["nameplates"], T["Always Show On Units With Missing HP"], C.nameplates, "fullhealth", "checkbox")
       CreateConfig(U["nameplates"], T["Always Show On Target Units"], C.nameplates, "target", "checkbox")
       CreateConfig(U["nameplates"], T["Vertical Healthbar"], C.nameplates, "verticalhealth", "checkbox")
+      CreateConfig(U["nameplates"], T["Overwrite Healthbar And Border Color With Agro State"], C.nameplates, "agrostate", "checkbox")
     end)
 
     CreateGUIEntry(T["Thirdparty"], T["Integrations"], function()

--- a/modules/nameplates.lua
+++ b/modules/nameplates.lua
@@ -582,7 +582,54 @@ pfUI:RegisterModule("nameplates", "vanilla:tbc", function ()
     end
 
     -- target indicator
-    if superwow_active and C.nameplates.outcombatstate == "1" then
+    if superwow_active and C.nameplates.agrostate == "1" then
+      local guid = plate.parent:GetName(1) or ""
+      local target = guid.."target"
+
+      if UnitAffectingCombat("player") and UnitAffectingCombat(guid) and not UnitCanAssist("player", guid) then
+        if UnitIsUnit(target, "player") then
+          plate.health.backdrop:SetBackdropBorderColor(0, 1, 0, 1)
+          plate.health:SetStatusBarColor(0, 1, 0, 1)
+        elseif UnitCastingInfo(guid) or UnitChannelInfo(guid) then
+        elseif UnitExists(target) then
+          if r ~= plate.cache.r or g ~= plate.cache.g or b ~= plate.cache.b then
+            plate.health:SetStatusBarColor(r, g, b, a)
+            plate.cache.r, plate.cache.g, plate.cache.b = r, g, b
+          end
+          if target and C.nameplates.targethighlight == "1" then
+            plate.health.backdrop:SetBackdropBorderColor(plate.health.hlr, plate.health.hlg, plate.health.hlb, plate.health.hla)
+          elseif C.nameplates.outfriendlynpc == "1" and unittype == "FRIENDLY_NPC" then
+            plate.health.backdrop:SetBackdropBorderColor(.2,.7,.3,1)
+          elseif C.nameplates.outfriendly == "1" and unittype == "FRIENDLY_PLAYER" then
+            plate.health.backdrop:SetBackdropBorderColor(.2,.3,.7,1)
+          elseif C.nameplates.outneutral == "1" and strfind(unittype, "NEUTRAL") then
+            plate.health.backdrop:SetBackdropBorderColor(.7,.7,.2,1)
+          elseif C.nameplates.outenemy == "1" and strfind(unittype, "ENEMY") then
+            plate.health.backdrop:SetBackdropBorderColor(.7,.2,.3,1)
+          else
+            plate.health.backdrop:SetBackdropBorderColor(er,eg,eb,ea)
+          end
+        end
+      else
+        if r ~= plate.cache.r or g ~= plate.cache.g or b ~= plate.cache.b then
+          plate.health:SetStatusBarColor(r, g, b, a)
+          plate.cache.r, plate.cache.g, plate.cache.b = r, g, b
+        end
+        if target and C.nameplates.targethighlight == "1" then
+          plate.health.backdrop:SetBackdropBorderColor(plate.health.hlr, plate.health.hlg, plate.health.hlb, plate.health.hla)
+        elseif C.nameplates.outfriendlynpc == "1" and unittype == "FRIENDLY_NPC" then
+          plate.health.backdrop:SetBackdropBorderColor(.2,.7,.3,1)
+        elseif C.nameplates.outfriendly == "1" and unittype == "FRIENDLY_PLAYER" then
+          plate.health.backdrop:SetBackdropBorderColor(.2,.3,.7,1)
+        elseif C.nameplates.outneutral == "1" and strfind(unittype, "NEUTRAL") then
+          plate.health.backdrop:SetBackdropBorderColor(.7,.7,.2,1)
+        elseif C.nameplates.outenemy == "1" and strfind(unittype, "ENEMY") then
+          plate.health.backdrop:SetBackdropBorderColor(.7,.2,.3,1)
+        else
+          plate.health.backdrop:SetBackdropBorderColor(er,eg,eb,ea)
+        end
+      end
+    elseif superwow_active and C.nameplates.outcombatstate == "1" then
       local guid = plate.parent:GetName(1) or ""
       local target = guid.."target"
 


### PR DESCRIPTION
Inspired by TankPlates by MarcelineVQ which is a great addon but makes you lag a lot. Therefore this implementation into pfUI which avoids the lag penalty.

Equivalent game logic from TankPlates has been implemented except no recoloring of nameplates to orange if the unit is affected by a specific debuff from a list of crowd controls.

Further considerations: 
- How it should interact with the "Overwrite Border Color With Combat State". Currently this new feature overwrites it. Maybe make it a drop down menu for exclusive choice?
- Removing in combat restrictions for better PvP usefulness. 

