### PR TITLE
nameplates: overwrite healthbar and border color with agro state

### DIFF
--- a/api/config.lua
+++ b/api/config.lua
@@ -728,6 +728,7 @@ function pfUI:LoadConfig()
   pfUI:UpdateConfig("nameplates", nil,           "totemicons",       "0")
   pfUI:UpdateConfig("nameplates", nil,           "showguildname",    "0")
 
+  pfUI:UpdateConfig("nameplates", nil,           "agrostate",        "0")
   pfUI:UpdateConfig("nameplates", nil,           "outcombatstate",   "1")
   pfUI:UpdateConfig("nameplates", nil,           "outfriendly",      "0")
   pfUI:UpdateConfig("nameplates", nil,           "outfriendlynpc",   "1")

--- a/modules/gui.lua
+++ b/modules/gui.lua
@@ -2288,6 +2288,7 @@ pfUI:RegisterModule("gui", "vanilla:tbc", function ()
       CreateConfig(U["nameplates"], T["Always Show On Units With Missing HP"], C.nameplates, "fullhealth", "checkbox")
       CreateConfig(U["nameplates"], T["Always Show On Target Units"], C.nameplates, "target", "checkbox")
       CreateConfig(U["nameplates"], T["Vertical Healthbar"], C.nameplates, "verticalhealth", "checkbox")
+      CreateConfig(U["nameplates"], T["Overwrite Healthbar And Border Color With Agro State"], C.nameplates, "agrostate", "checkbox")
     end)
 
     CreateGUIEntry(T["Thirdparty"], T["Integrations"], function()

--- a/modules/nameplates.lua
+++ b/modules/nameplates.lua
@@ -712,6 +712,23 @@ pfUI:RegisterModule("nameplates", "vanilla:tbc", function ()
       r, g, b, a = .5, .5, .5, .8
     end
 
+    if superwow_active and C.nameplates.agrostate == "1" then
+      local guid = plate.parent:GetName(1) or ""
+      local target = guid.."target" 
+
+      if UnitAffectingCombat("player") and UnitAffectingCombat(guid) and not UnitCanAssist("player", guid) then
+        if UnitIsUnit(target, "player") then
+          r, g, b, a = 0, 1, 0, 1
+          plate.health.backdrop:SetBackdropBorderColor(r, g, b, a) 
+        elseif UnitCastingInfo(guid) or UnitChannelInfo(guid) or not UnitExists(target) then
+          if plate.cache.r == 0 and plate.cache.g == 1 and plate.cache.b == 0 then 
+            r, g, b, a = 0, 1, 0, 1
+            plate.health.backdrop:SetBackdropBorderColor(r, g, b, a)
+          end
+        end
+      end
+    end
+      
     if r ~= plate.cache.r or g ~= plate.cache.g or b ~= plate.cache.b then
       plate.health:SetStatusBarColor(r, g, b, a)
       plate.cache.r, plate.cache.g, plate.cache.b = r, g, b


### PR DESCRIPTION
Inspired by TankPlates by MarcelineVQ which is a great addon but makes you lag a lot. Therefore this implementation into pfUI which avoids the lag penalty.

Equivalent game logic from TankPlates has been implemented except no recoloring of nameplates to orange if the unit is affected by a specific debuff from a list of crowd controls.

Further considerations:
- Adding the logic of recoloring the nameplates orange if the unit is affected by hard CC.
- Removing in combat restrictions for better PvP usefulness.