### PR TITLE
eliminates tracking button for earthshaker slam

### DIFF
--- a/modules/tracking.lua
+++ b/modules/tracking.lua
@@ -160,6 +160,12 @@ pfUI:RegisterModule("tracking", "vanilla", function ()
                 state.spells[texture] = {
                   index = spellIndex,
                   name = GetSpellName(spellIndex, BOOKTYPE_SPELL),
+                  
+                  -- shows up as clickable ability for shaman on turtle. better way?
+                  if name == "Earthshaker Slam" then
+                    continue
+                  end
+                  
                   texture = spellTexture
                 }
             end


### PR DESCRIPTION
On Turtle shaman 'Earthshaker Slam' triggers the tracking button to pop up with a question mark icon. If you click it it tries to cast. This fix skips it on spellbook detect. I don't know if other servers have this ability or how to otherwise keep it specific to turtle.