### PR TITLE
targetarg support for superwow/cleveroidmacros

### DIFF
--- a/libs/libpredict.lua
+++ b/libs/libpredict.lua
@@ -399,33 +399,26 @@ hooksecurefunc("CastSpell", function(id, bookType)
   spell_queue[3] = UnitName("target") and UnitCanAssist("player", "target") and UnitName("target") or UnitName("player")
 end, true)
 
-hooksecurefunc("CastSpellByName", function(effect, targetArg) -- Captures the optional target argument
-  -- ... standard checks ...
-  local effectName, rank = libspell.GetSpellInfo(effect)
-  if not effectName then return end
+hooksecurefunc("CastSpellByName", function(effect, targetArg)
+  local effect, rank = libspell.GetSpellInfo(effect)
+  if not effect then return end
 
   local determinedTargetName = nil
 
-  if targetArg then -- <--- THIS IS THE KEY CHECK
-    -- If a target unitID was explicitly passed (targetArg is not nil), use its name.
-    -- This ONLY happens when CleveRoids calls it in the "hasSuperwow" case.
+  if targetArg then
     determinedTargetName = UnitName(targetArg)
   else
-    -- If no target was passed (targetArg is nil), use libpredict's original fallback logic.
-    -- This happens for normal casts or when CleveRoids calls it without Superwow.
     local mouseoverUnit = pfUI and pfUI.uf and pfUI.uf.mouseover and pfUI.uf.mouseover.unit
     local mouseoverName = mouseoverUnit and UnitCanAssist("player", mouseoverUnit) and UnitName(mouseoverUnit)
     local defaultName = UnitName("target") and UnitCanAssist("player", "target") and UnitName("target") or UnitName("player")
     determinedTargetName = mouseoverName or defaultName
   end
 
-  -- ... update spell_queue[3] with determinedTargetName ...
   if determinedTargetName then
       spell_queue[1] = effectName
       spell_queue[2] = effectName .. ( rank or "" )
       spell_queue[3] = determinedTargetName
   end
-
 end, true)
 
 local scanner = libtipscan:GetScanner("prediction")


### PR DESCRIPTION
In order to allow pfui to support @mouseover casted buff and debuff timers with superwow/cleveroidmacros, i have edited the libpredict.lua. 
When CleveRoids.hasSuperwow is true, CleveRoids calls CastSpellByName with two arguments. The hook sees targetArg is not nil and uses the target provided by CleveRoids.
When CleveRoids.hasSuperwow is false (or for any other addon/default UI call), CastSpellByName is called with only one argument. The hook sees targetArg is nil and uses libpredict's original logic (checking pfUI mouseover or the current target).