### PR TITLE
fixes earthshaker slam in tracking display on turtle

### DIFF
--- a/modules/tracking.lua
+++ b/modules/tracking.lua
@@ -41,6 +41,10 @@ pfUI:RegisterModule("tracking", "vanilla", function ()
     }
   }
 
+  local invalidTrackingSpells = {
+    ["Earthshaker Slam"] = true
+  }
+
   local state = {
     texture = nil,
     spells = {}
@@ -145,11 +149,15 @@ pfUI:RegisterModule("tracking", "vanilla", function ()
         -- scan for generic tracking icons
         for _, texture in pairs(knownTrackingSpellTextures["any"]) do
           if spellTexture and strfind(spellTexture, texture) and not state.spells[texture] then
-            -- check for valid tracking spell. test against known bugged display
-            -- only loads table if spell name not blocked. better way to do this?
+            -- search table added for spells that may have same texture but not be tracking
+            local function validateTracking(tracktocheck)
+              return not invalidTrackingSpells[tracktocheck]
+            end
+
+            -- get spell name to validate
             local validTracking = GetSpellName(spellIndex, BOOKTYPE_SPELL)
-            -- shaman spell on turtle earthshaker slam shows up and is clickable tracking icon
-            if validTracking ~= "Earthshaker Slam" then
+            -- only add to state.spells if not invalid item in list
+            if validateTracking(validTracking) then
               state.spells[texture] = {
                 index = spellIndex,
                 name = validTracking,

--- a/modules/tracking.lua
+++ b/modules/tracking.lua
@@ -145,11 +145,17 @@ pfUI:RegisterModule("tracking", "vanilla", function ()
         -- scan for generic tracking icons
         for _, texture in pairs(knownTrackingSpellTextures["any"]) do
           if spellTexture and strfind(spellTexture, texture) and not state.spells[texture] then
-            state.spells[texture] = {
-              index = spellIndex,
-              name = GetSpellName(spellIndex, BOOKTYPE_SPELL),
-              texture = spellTexture
-            }
+            -- check for valid tracking spell. test against known bugged display
+            -- only loads table if spell name not blocked. better way to do this?
+            local validTracking = GetSpellName(spellIndex, BOOKTYPE_SPELL)
+            -- shaman spell on turtle earthshaker slam shows up and is clickable tracking icon
+            if validTracking ~= "Earthshaker Slam" then
+              state.spells[texture] = {
+                index = spellIndex,
+                name = validTracking,
+                texture = spellTexture
+              }
+            end
           end
         end
 


### PR DESCRIPTION
I'm unsure if there is a better way as in comments. Earthshaker Slam shaman ability shows up in tracking icon for Turtle WoW. This skips it when loading known tracking modes.