### PR TITLE
fix: handle 24-hour to 12-hour clock conversion edge cases. 00:00 and…

### DIFF
--- a/modules/afkcam.lua
+++ b/modules/afkcam.lua
@@ -99,7 +99,12 @@ pfUI:RegisterModule("afkcam", "vanilla:tbc", function ()
     local time = ""
     if C.global.twentyfour == "0" then
       if C.global.servertime == "1" then
-        if h > 12 then
+        if h == 0 then
+          h = 12
+          noon = "AM"
+        elseif h == 12 then
+          noon = "PM"
+        elseif h > 12 then
           h = h - 12
           noon = "PM"
         end

--- a/modules/afkcam.lua
+++ b/modules/afkcam.lua
@@ -101,7 +101,6 @@ pfUI:RegisterModule("afkcam", "vanilla:tbc", function ()
       if C.global.servertime == "1" then
         if h == 0 then
           h = 12
-          noon = "AM"
         elseif h == 12 then
           noon = "PM"
         elseif h > 12 then

--- a/modules/panel.lua
+++ b/modules/panel.lua
@@ -17,7 +17,12 @@ pfUI:RegisterModule("panel", "vanilla:tbc", function()
         local servertime
         local time
         if C.global.twentyfour == "0" then
-          if h > 12 then
+          noon = " AM"
+          if h == 0 then
+            h = 12
+          elseif h == 12 then
+            noon = " PM"
+          elseif h > 12 then
             h = h - 12
             noon = " PM"
           end
@@ -67,7 +72,12 @@ pfUI:RegisterModule("panel", "vanilla:tbc", function()
         local secondsenabled = C.panel.seconds == "1"
         if C.global.twentyfour == "0" then
           if C.global.servertime == "1" then
-            if h > 12 then
+            if h == 0 then
+              h = 12
+              noon = "AM"
+            elseif h == 12 then
+              noon = "PM"
+            elseif h > 12 then
               h = h - 12
               noon = "PM"
             end

--- a/modules/panel.lua
+++ b/modules/panel.lua
@@ -17,7 +17,6 @@ pfUI:RegisterModule("panel", "vanilla:tbc", function()
         local servertime
         local time
         if C.global.twentyfour == "0" then
-          noon = " AM"
           if h == 0 then
             h = 12
           elseif h == 12 then
@@ -74,7 +73,6 @@ pfUI:RegisterModule("panel", "vanilla:tbc", function()
           if C.global.servertime == "1" then
             if h == 0 then
               h = 12
-              noon = "AM"
             elseif h == 12 then
               noon = "PM"
             elseif h > 12 then

--- a/modules/turtle-wow.lua
+++ b/modules/turtle-wow.lua
@@ -146,12 +146,22 @@ pfUI:RegisterModule("turtle-wow", "vanilla", function ()
         if C.global.twentyfour == "0" then
           local zn, sn = " AM", " AM"
 
-          if zh > 12 then
+          if zh == 0 then
+            zh = 12
+            zn = " AM"
+          elseif zh == 12 then
+            zn = " PM"
+          elseif zh > 12 then
             zh = zh - 12
             zn = " PM"
           end
 
-          if sh > 12 then
+          if sh == 0 then
+            sh = 12
+            sn = " AM"
+          elseif sh == 12 then
+            sn = " PM"
+          elseif sh > 12 then
             sh = sh - 12
             sn = " PM"
           end

--- a/modules/turtle-wow.lua
+++ b/modules/turtle-wow.lua
@@ -148,7 +148,6 @@ pfUI:RegisterModule("turtle-wow", "vanilla", function ()
 
           if zh == 0 then
             zh = 12
-            zn = " AM"
           elseif zh == 12 then
             zn = " PM"
           elseif zh > 12 then
@@ -158,7 +157,6 @@ pfUI:RegisterModule("turtle-wow", "vanilla", function ()
 
           if sh == 0 then
             sh = 12
-            sn = " AM"
           elseif sh == 12 then
             sn = " PM"
           elseif sh > 12 then


### PR DESCRIPTION
# Overview
There is a bug when converting the 24-hour clock to a 12-hour clock.

## Issue
00:00 -> 00:00am
12:00 -> 12:00am

## Correct way
00:00 -> 12:00am
12:00 -> 12:00pm

These updates should fix the issue