### PR TITLE
Update unitframes.lua

### DIFF
--- a/api/unitframes.lua
+++ b/api/unitframes.lua
@@ -2602,7 +2602,7 @@ function pfUI.uf.GetColor(self, preset)
   end
 
   -- pastel
-  if C.unitframes.pastel == "1" and not (config["classcolor"] == "1" and UnitIsPlayer(unitstr)) then
+  if C.unitframes.pastel == "1" and not (preset == "unit" and config["classcolor"] == "1" and UnitIsPlayer(unitstr)) then
     r = ( r + .75 ) * .5
     g = ( g + .75 ) * .5
     b = ( b + .75 ) * .5

--- a/api/unitframes.lua
+++ b/api/unitframes.lua
@@ -2602,12 +2602,10 @@ function pfUI.uf.GetColor(self, preset)
   end
 
   -- pastel
-  if C.unitframes.pastel == "1" then
-    if not (preset == "unit" and config["classcolor"] == "1" and UnitIsPlayer(unitstr)) then
-      r = ( r + .75 ) * .5
-      g = ( g + .75 ) * .5
-      b = ( b + .75 ) * .5
-    end
+  if C.unitframes.pastel == "1" and not (config["classcolor"] == "1" and UnitIsPlayer(unitstr)) then
+    r = ( r + .75 ) * .5
+    g = ( g + .75 ) * .5
+    b = ( b + .75 ) * .5
   end
 
   return rgbhex(r,g,b)

--- a/api/unitframes.lua
+++ b/api/unitframes.lua
@@ -2603,9 +2603,11 @@ function pfUI.uf.GetColor(self, preset)
 
   -- pastel
   if C.unitframes.pastel == "1" then
-    r = ( r + .75 ) * .5
-    g = ( g + .75 ) * .5
-    b = ( b + .75 ) * .5
+    if not (preset == "unit" and config["classcolor"] == "1" and UnitIsPlayer(unitstr)) then
+      r = ( r + .75 ) * .5
+      g = ( g + .75 ) * .5
+      b = ( b + .75 ) * .5
+    end
   end
 
   return rgbhex(r,g,b)


### PR DESCRIPTION
Prevent class colored names to look washed out (especially druid is affected by this and me personally can't differentiate between druids and warriors anymore):

Apply pastel if NOT both are true:
- preset == "unit"
- config["classcolor"] == "1"
- UnitIsPlayer(unitstr)

Before:
![image](https://github.com/user-attachments/assets/e9bea71a-0b3d-4e00-ae2a-807e94202462)

Now:
![image](https://github.com/user-attachments/assets/4a7be022-f8e2-4402-a1c8-f5bb7d3b5fe7)

