### PR TITLE
Optimize /castfocus using superwow and memoization and Co-optimize /cast as well via memoization

### DIFF
--- a/api/api.lua
+++ b/api/api.lua
@@ -27,7 +27,7 @@ end
 -- return:      [boolean]       result of the check.
 function pfUI.api.isempty(tbl)
   if not tbl then return true end
-  for k, v in pairs(tbl) do
+  for _ in pairs(tbl) do
     return false
   end
   return true
@@ -80,8 +80,12 @@ function pfUI.api.RunOOC(func)
   if not frame then
     frame = CreateFrame("Frame")
     frame:SetScript("OnUpdate", function()
-      if InCombatLockdown and InCombatLockdown() then return end
-      for key, func in pairs(queue) do func(); queue[key] = nil end
+        if InCombatLockdown and InCombatLockdown() then return end
+
+        for k, f in pairs(queue) do
+            f()
+            queue[k] = nil
+        end
     end)
   end
 

--- a/modules/focus.lua
+++ b/modules/focus.lua
@@ -77,7 +77,7 @@ function SlashCmdList.PFCASTFOCUS(msg)
     end
   end
 
-  local func = loadstring(msg or "")
+  local func = pfUI.api.TryMemoizedFuncLoadstringForSpellCasts(msg)
   if func then
     func()
   else

--- a/modules/focus.lua
+++ b/modules/focus.lua
@@ -95,7 +95,7 @@ function SlashCmdList.PFCASTFOCUS(msg)
 end
 
 SLASH_PFSWAPFOCUS1, SLASH_PFSWAPFOCUS2 = '/swapfocus', '/pfswapfocus'
-function SlashCmdList.PFSWAPFOCUS(msg)
+function SlashCmdList.PFSWAPFOCUS()
   if not pfUI.uf or not pfUI.uf.focus then return end
 
   local oldunit = UnitExists("target") and strlower(UnitName("target"))

--- a/modules/mouseover.lua
+++ b/modules/mouseover.lua
@@ -34,7 +34,7 @@ pfUI:RegisterModule("mouseover", "vanilla", function ()
   _G.SLASH_PFCAST1, _G.SLASH_PFCAST2 = "/pfcast", "/pfmouse"
   function SlashCmdList.PFCAST(msg)
     local restore_target = true
-    local func = loadstring(msg or "")
+    local func = pfUI.api.TryMemoizedFuncLoadstringForSpellCasts(msg)
     local unit = "mouseover"
 
     if not UnitExists(unit) then

--- a/modules/superwow.lua
+++ b/modules/superwow.lua
@@ -49,7 +49,7 @@ pfUI:RegisterModule("superwow", "vanilla", function ()
   -- Add native mouseover support
   if SUPERWOW_VERSION and pfUI.uf and pfUI.uf.mouseover then
     _G.SlashCmdList.PFCAST = function(msg)
-      local func = loadstring(msg or "")
+      local func = pfUI.api.TryMemoizedFuncLoadstringForSpellCasts(msg)
       local unit = "mouseover"
 
       if not UnitExists(unit) then

--- a/modules/superwow.lua
+++ b/modules/superwow.lua
@@ -36,7 +36,7 @@ pfUI:RegisterModule("superwow", "vanilla", function ()
     QueueFunction(function()
       local pfCombatText_AddMessage = _G.CombatText_AddMessage
       _G.CombatText_AddMessage = function(message, a, b, c, d, e, f)
-        local match, _, hex = string.find(message, ".+ %[(0x.+)%]")
+        local _, _, hex = string.find(message, ".+ %[(0x.+)%]")
         if hex and UnitName(hex) then
           message = string.gsub(message, hex, UnitName(hex))
         end
@@ -90,7 +90,7 @@ pfUI:RegisterModule("superwow", "vanilla", function ()
     local config = pfUI.uf.player.config
     local mana = config.defcolor == "0" and config.manacolor or pfUI_config.unitframes.manacolor
     local r, g, b, a = pfUI.api.strsplit(",", mana)
-    local rawborder, default_border = GetBorderSize("unitframes")
+    local _, default_border = GetBorderSize("unitframes")
     local _, class = UnitClass("player")
     local width = config.pwidth ~= "-1" and config.pwidth or config.width
 
@@ -257,7 +257,7 @@ pfUI:RegisterModule("superwow", "vanilla", function ()
   superdebuff:RegisterEvent("UNIT_CASTEVENT")
   superdebuff:SetScript("OnEvent", function()
     -- variable assignments
-    local caster, target, event, spell, duration = arg1, arg2, arg3, arg4
+    local caster, target, event, spell = arg1, arg2, arg3
 
     -- skip other caster and empty target events
     local _, guid = UnitExists("player")
@@ -270,7 +270,7 @@ pfUI:RegisterModule("superwow", "vanilla", function ()
     local unitlevel = UnitLevel(target)
     local effect, rank = SpellInfo(spell)
     local duration = libdebuff:GetDuration(effect, rank)
-    local caster = "player"
+    caster = "player"
 
     -- add effect to current debuff data
     libdebuff:AddEffect(unit, unitlevel, effect, duration, caster)
@@ -306,11 +306,11 @@ pfUI:RegisterModule("superwow", "vanilla", function ()
     if arg3 == "START" or arg3 == "CAST" or arg3 == "CHANNEL" then
       -- human readable argument list
       local guid = arg1
-      local target = arg2
+      -- local target = arg2
       local event_type = arg3
       local spell_id = arg4
       local timer = arg5
-      local start = GetTime()
+      -- local start = GetTime()
 
       -- get spell info from spell id
       local spell, icon, _


### PR DESCRIPTION
- Add support for superwow-aware SlashCmdList.PFCASTFOCUS() just like we did with SlashCmdList.PFFOCUS

This allows us to employ unit-guid-targeting to side-step the complex target-swapping tricks we would resort to when superwow wasn't available.
   
This is a much more care-free and lightweight approach.

- Replace loadstring() calls in _G.SlashCmdList.PFCAST() and SlashCmdList.PFCASTFOCUS() with the new pfUI.api.TryMemoizedFuncLoadstringForSpellCasts() to enjoy better runtime performance when the user passes lua-func-strings (considering that they're the same strings time and over again).

As an added bonus this commit also adds seamless support for passing actual raw functions to SlashCmdList.PFCASTFOCUS() ala:

```lua
SlashCmdList.PFCASTFOCUS(function() CastspellByName("Renew" .. desiredRank); end)
``` 

This is extremely useful for advanced pure-lua macros (p.e. via SuperMacro) as it simplifies the invocation-style tremendously.

Old was: Before this commit we would have to write this kind of stuff as a string

```lua
SlashCmdList.PFCASTFOCUS( 'function() CastspellByName("Renew"' .. desiredRank .. '); end' )  -- notice we had to use a "string-function" here!
```

This was both 10x slower and was extremely cumbersome and error-prone for the user if he wanted to pass some variable-state inside the string-func-callback (god help him in that case!)